### PR TITLE
Allow to use schema's properties 'title' and 'default' insted Fields

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -16,9 +16,17 @@ export default class Form {
   ajvExtend = null;
 
   constructor({ fields = {}, schema = false, options = {}, extend = null }) {
-    const keys = Object.keys(fields);
+    const objectFields = fields;
+    if (Object.keys(objectFields).length === 0 && !!schema) {
+      Object.keys(schema.properties).forEach((property) => {
+        const label = schema.properties[property].title;
+        const value = schema.properties[property].default;
+        objectFields[property] = { label, value };
+      });
+    }
+    const keys = Object.keys(objectFields);
     this.initAjv(schema, options, extend);
-    this.initFields(keys, fields);
+    this.initFields(keys, objectFields);
     this.validateFields(false, false);
   }
 

--- a/tests/data/form.h.js
+++ b/tests/data/form.h.js
@@ -1,0 +1,14 @@
+import Form from '../../src/index';
+import extend from './extend';
+
+const schema = {
+  type: 'object',
+  properties: {
+    username: { type: 'string', minLength: 6, maxLength: 20, title: 'Username', default:'SteveJobs' },
+    email: { type: 'string', format: 'email', minLength: 5, maxLength: 20, title: 'Email', default: 's.jobs@apple.com'},
+    password: { type: 'string', minLength: 6, maxLength: 20, title: 'Password', default: 'thinkdifferent'},
+    devSkills: { range: [5, 10], /*title: 'Dev Skills', default: 5 */},
+  },
+};
+
+export default new Form({ schema, extend });

--- a/tests/test.js
+++ b/tests/test.js
@@ -8,6 +8,7 @@ import $D from './data/form.d.js';
 import $E from './data/form.e.js';
 import $F from './data/form.f.js';
 import $G from './data/form.g.js';
+import $H from './data/form.h.js';
 
 // do some stuff
 $C.invalidate('The user already exist');
@@ -23,6 +24,7 @@ describe('mobx-ajv-form', () => {
   it('$E isValid should be true', () => expect($E.isValid).to.be.true);
   it('$F isValid should be false', () => expect($F.isValid).to.be.false);
   it('$G isValid should be true', () => expect($G.isValid).to.be.true);
+  it('$H isValid should be true', () => expect($H.isValid).to.be.true);
 
   // test isDirty
   it('$A isDirty should be false', () => expect($A.isDirty).to.be.false);
@@ -39,4 +41,17 @@ describe('mobx-ajv-form', () => {
 
   it('$D username should be equal to "Jonathan Ive"', () =>
     expect($D.fields.username.value).to.be.equal('Jonathan Ive'));
+
+  it('$H username should be equal to "SteveJobs"', () =>
+    expect($H.fields.username.value).to.be.equal('SteveJobs'));
+
+  it('$H email value should be equal to "s.jobs@apple.com"', () =>
+    expect($H.fields.email.value).to.be.equal('s.jobs@apple.com'));
+
+  it('$H email label should be equal to "Email"', () =>
+    expect($H.fields.email.label).to.be.equal('Email'));
+
+  it('$H devSkills should be equal to ""', () =>
+    expect($H.fields.devSkills.value).to.be.equal(''));
+
 });


### PR DESCRIPTION
It allows to create a new Form only using s JSON-Schema, without Fields, using de 'title' and 'default' properties in the schema, insted 'label' and 'value' in the Fields.
