### PR TITLE
Add babel-register to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "homepage": "https://www.npmjs.com/package/mobx-react-form",
   "main": "lib/index.js",
   "scripts": {
-    "clean:lib": "rm -rf lib",
-    "clean:umd": "rm -rf umd",
+    "clean:lib": "rimraf lib",
+    "clean:umd": "rimraf umd",
     "clean:all": "npm run clean:lib && npm run clean:umd",
-    "clean:modules": "rm -rf ./node_modules && npm cache clean",
+    "clean:modules": "rimraf ./node_modules && npm cache clean",
     "lint": "eslint . --ext .jsx,.js --ignore-path .gitignore",
     "build": "npm-run-all --parallel build:*",
     "build:main": "babel -d lib/ src/",
@@ -86,6 +86,7 @@
     "npm-run-all": "3.1.0",
     "nyc": "8.3.0",
     "path": "0.12.7",
+    "rimraf": "2.5.4",
     "semantic-release": "4.3.5",
     "validatorjs": "3.7.0",
     "webpack": "1.13.2"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-preset-es2015": "6.14.0",
     "babel-preset-stage-0": "6.5.0",
+    "babel-register": "6.16.3",
     "chai": "3.5.0",
     "codecov": "1.0.1",
     "commitizen": "2.8.6",


### PR DESCRIPTION
We need to add the babel-register to the devDependencies. Without it I cannot run the unit tests. 
