### PR TITLE
Add babel-register to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-preset-es2015": "6.14.0",
     "babel-preset-stage-0": "6.5.0",
+    "babel-register": "6.16.3",
     "chai": "3.5.0",
     "codecov": "1.0.1",
     "commitizen": "2.8.6",


### PR DESCRIPTION
We need to add the babel-register to the devDependencies. Without it I cannot run the unit tests.
