### PR TITLE
Downgrade eslint-plugin-import to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "cz-conventional-changelog": "1.2.0",
     "eslint": "3.7.1",
     "eslint-config-airbnb": "12.0.0",
-    "eslint-plugin-import": "2.0.0",
+    "eslint-plugin-import": "1.16.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
     "eslint-plugin-react": "6.3.0",
     "ghooks": "1.3.2",


### PR DESCRIPTION
I have the problems when I run npm install after upgrading eslint-plugin-import to 2.0.0

```
npm WARN eslint-config-airbnb@12.0.0 requires a peer of eslint-plugin-import@^1.16.0 but none was installed.
npm WARN eslint-config-airbnb-base@8.0.0 requires a peer of eslint-plugin-import@^1.16.0 but none was installed.
```

https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/package.json#L66
