### PR TITLE
extend validatin rules support for DVR plugin, solve #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ const fields = [{
   name: 'password',
   label: 'Password',
   rules: 'required|string|between:5,25',
+}, {
+  name: 'confirm_password',
+  label: 'Password Confirmation',
+  rules: 'same:password',
 }];
 ```
 

--- a/src/FieldHelpers.js
+++ b/src/FieldHelpers.js
@@ -324,4 +324,51 @@ export default $this => ({
       check.push(utils.check({ type: $, data: $deep }));
       return check;
     }, []),
+
+  /**
+     * Iterates deeply over fields and invokes `iteratee` for each element.
+     * The iteratee is invoked with three arguments: (value, index|key, depth).
+     *
+     * @param {Function} The function invoked per iteration.
+     * @param {Array|Object} [fields=form.fields] fields to iterate over.
+     * @param {number} [depth=1] The recursion depth for internal use.
+     * @returns {Array} Returns [fields.values()] of input [fields] parameter.
+     * @example
+     *
+     * JSON.stringify(form)
+     * // => {
+     *   "fields": {
+     *     "state": {
+     *       "fields": {
+     *         "city": {
+     *           "fields": { "places": {
+     *                "fields": {},
+     *                "key": "places", "path": "state.city.places", "$value": "NY Places"
+     *              }
+     *           },
+     *           "key": "city", "path": "state.city", "$value": "New York"
+     *         }
+     *       },
+     *       "key": "state", "path": "state", "$value": "USA"
+     *     }
+     *   }
+     * }
+     *
+     * const data = {};
+     * form.forEach(formField => data[formField.path] = formField.value);
+     * // => {
+     *   "state": "USA",
+     *   "state.city": "New York",
+     *   "state.city.places": "NY Places"
+     * }
+     *
+     */
+  forEach: (iteratee, fields = $this.fields, depth = 0) =>
+    _.each(fields.values(), (field, index) => {
+      iteratee(field, index, depth);
+
+      if (field.fields.size !== 0) {
+        $this.forEach(iteratee, field.fields, depth + 1);
+      }
+    }),
 });

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -104,7 +104,7 @@ export default class Validator {
     // validate with vanilla js functions (vjf)
     if (vjf) vjf.validateField($field, form);
     // validate with json schema validation keywords (dvr)
-    if (dvr) dvr.validateField($field);
+    if (dvr) dvr.validateField($field, form);
     // validate with json schema validation keywords (svk)
     if (svk) svk.validateField($field);
     // send error to the view

--- a/src/validators/DVR.js
+++ b/src/validators/DVR.js
@@ -46,18 +46,23 @@ export default class DVR {
     if (_.isFunction(this.extend)) this.extend(this.validator);
   }
 
-  validateField(field) {
-    this.validateFieldAsync(field);
-    this.validateFieldSync(field);
+  validateField(field, form) {
+    // get form fields data
+    const data = {};
+    form.forEach((formField) => {
+      data[formField.path] = formField.value;
+    });
+
+    this.validateFieldAsync(field, form, data);
+    this.validateFieldSync(field, form, data);
   }
 
-  validateFieldSync(field) {
+  validateFieldSync(field, form, data) {
     const $rules = this.rules(field.rules, 'sync');
     // exit if no rules found
     if (_.isEmpty($rules[0])) return;
-    // get field data and rules
-    const data = { [field.key]: field.value };
-    const rules = { [field.key]: $rules };
+    // get field rules
+    const rules = { [field.path]: $rules };
     // create the validator instance
     const Validator = this.validator;
     const validation = new Validator(data, rules);
@@ -69,12 +74,11 @@ export default class DVR {
     field.setInvalid(_.first(validation.errors.get(field.key)));
   }
 
-  validateFieldAsync(field) {
+  validateFieldAsync(field, form, data) {
     const $rules = this.rules(field.rules, 'async');
     // exit if no rules found
     if (_.isEmpty($rules[0])) return;
-    // get field data and rules
-    const data = { [field.key]: field.value };
+    // get field rules
     const rules = { [field.key]: $rules };
     // create the validator instance
     const Validator = this.validator;

--- a/tests/data/forms/flat/form.a.js
+++ b/tests/data/forms/flat/form.a.js
@@ -25,6 +25,16 @@ const fields = {
   password: {
     label: 'Password',
     value: 'thinkdifferent',
+    rules: 'confirmed',
+  },
+  passwordConfirmation1: {
+    label: 'Password Confirmation 1',
+    value: 'thinkdifferent',
+    rules: 'required|same:password',
+  },
+  password_confirmation: {
+    label: 'Password Confirmation 2',
+    value: 'thinkdifferent',
   },
   terms: {
     label: 'Accept Terms',


### PR DESCRIPTION
Use all form field values to perform validation with dvr rules (confirmed, same,..) that need data from more than one field.