### PR TITLE
Call noop if form has no validation handlers

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -236,8 +236,8 @@ export const prototypes = {
     Submit Form
   */
   @action submit(o = {}) {
-    const execOnSuccess = _.has(o, 'onSuccess') ? o.onSuccess : this.onSuccess;
-    const execOnError = _.has(o, 'onError') ? o.onError : this.onError;
+    const execOnSuccess = _.has(o, 'onSuccess') ? o.onSuccess : () => {};
+    const execOnError = _.has(o, 'onError') ? o.onError : () => {};
 
     this.validate()
       .then(isValid => isValid


### PR DESCRIPTION
Fixes an Uncaught TypeError if a Form has no `onSuccess` or `onError` handler