### PR TITLE
Form: onSubmit: return promise

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -53,7 +53,7 @@ export default class Base {
    */
   onSubmit = (e, o = {}) => {
     e.preventDefault();
-    this.submit(o);
+    return this.submit(o);
   };
 
   /**

--- a/tests/flat.submit.js
+++ b/tests/flat.submit.js
@@ -13,6 +13,17 @@ describe('Form submit() decoupled callback', () => {
     });
   });
 
+  // $I
+  it('$I.submit() should return a promise rejected by the onSuccess callback', () => {
+    const err = new Error('boom');
+    return $.$I.submit({
+      onSuccess: () => Promise.reject(err),
+    })
+      .catch((v) => {
+        expect(v).to.equal(err);
+      });
+  });
+
   // $N
   it('$N.submit() should call onError callback on invalid form', (done) => {
     $.$N.submit({


### PR DESCRIPTION
I am looking for a way to better manage errors from the `onSubmit` action. My idea is to use the promise return from the `onSuccess` callback.
I would like to all my forms to have the same behavior:
- Toggle a boolean observable `submitting` during transaction
- Use potential error from rejected promise and invalidate the form with the error message or maybe store it in another observable.

Inspired by [rfx-stack base form class](https://github.com/foxhound87/rfx-stack/blob/master/src/shared/forms/_.extend.js), code might look like that:
```js
class Form extends MobxReactForm {
  @observable $submitting = false

  @action onSubmitBegin = () => { this.$submitting = true }
  @action onSubmitFinish = () => { this.$submitting = false }
  handleSubmit = (e) => {
    this.onSubmitBegin()

    this.onSubmit(e)
      .then(this.onSubmitFinish)
      .catch((err) => {
        this.onSubmitFinish()
        this.invalidate(err.message)
      })
  }

  @computed get submitting () {
    return this.$submitting
  }
}
```

I am totally new in the code base so I ventured to write some tests for illustrate it but feel free to wipe it all.

Thanks for this great library.

