### PR TITLE
Promise handling

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -60,7 +60,7 @@ export default class Base {
    */
   onSubmit = (e, o = {}) => {
     e.preventDefault();
-    this.submit(o);
+    return this.submit(o);
   };
 
   /**

--- a/src/shared/Actions.js
+++ b/src/shared/Actions.js
@@ -40,6 +40,10 @@ export default {
           return handler;
         })
         .then(action(() => (this.$submitting = false)))
+        .catch(action((err) => {
+          this.$submitting = false;
+          throw err;
+        }))
         .then(() => this);
 
 


### PR DESCRIPTION
- #### Base: onSubmit: return the promise resulted by `this.submit()`
It will allows to wait or catch the promise resulted from the form submit.

- #### Actions: submit: set `$submitting` to `false` when the `onSuccess` or `onError` result a rejected promise.
If the form method `onSubmitSuccess` result a rejected promise, the `$submitting` will never get back to `false`.