### PR TITLE
pathToStruct() returns wrong value 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,7 @@ const throwError = (path, fields, msg = null) => {
 
 const pathToStruct = (path) => {
   let struct;
-  struct = _.replace(path, new RegExp('[.]\\d($|.)', 'g'), '[].');
+  struct = _.replace(path, new RegExp('[.]\\d+($|.)', 'g'), '[].');
   struct = _.replace(struct, '..', '.');
   struct = _.trim(struct, '.');
   return struct;


### PR DESCRIPTION

**pathToStruct()** return wrong value when path is like "_orderItems.105_", it will return "_orderItems[].5_" which case the initField can not get the right options.

Because of the RegExp about number doesn`t deal with length.

So i change  \d  to  \d+ to make sure it works.