### PR TITLE
Add default onDrop value

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -367,9 +367,9 @@ export const prototypes = {
       } = $data;
 
       this.type = $type || type || 'text';
-      this.$onDrop = $onDrop || onDrop || null;
       this.$onSubmit = $onSubmit || onSubmit || null;
       this.$onClear = $onClear || onClear || this.noop;
+      this.$onDrop = $onDrop || onDrop || this.noop;
       this.$onReset = $onReset || onReset || this.noop;
 
       this.$parser = $try($parse, parse, this.$parser);
@@ -410,9 +410,9 @@ export const prototypes = {
     /* The field IS the value here */
     this.name = _.toString($key);
     this.type = $type || 'text';
-    this.$onDrop = $onDrop || null;
     this.$onSubmit = $onSubmit || null;
     this.$onClear = $onClear || this.noop;
+    this.$onDrop = $onDrop || this.noop;
     this.$onReset = $onReset || this.noop;
 
     this.$parser = $try($parse, this.$parser);


### PR DESCRIPTION
Hi,
When using mobx-react-form with input type files, it will throw an exception when you try to select a file, because onDrop doesn't exist.  I've been getting around this by putting noops while initializing the form to handle onDrop cases, but that gets hairy, especially when defining nested array fields.  This pull requests sets onDrops default value to noop.  It would be awesome if you could merge this.

Thanks!