### PR TITLE
fix: validate, flatten promise (fix missing propagation of errors)

### DIFF
--- a/src/Validator.js
+++ b/src/Validator.js
@@ -87,21 +87,21 @@ export default class Validator {
           related,
         }));
 
-      // wait all promises then resolve
-      return Promise.all(this.promises)
-        .then(action(() => {
-          instance.$validating = false;
-          instance.$clearing = false;
-          instance.$resetting = false;
-        }))
-        .catch(action((err) => {
-          instance.$validating = false;
-          instance.$clearing = false;
-          instance.$resetting = false;
-          throw err;
-        }))
-        .then(() => resolve(instance));
-    });
+      // wait all promises
+      resolve(Promise.all(this.promises));
+    })
+      .then(action(() => {
+        instance.$validating = false;
+        instance.$clearing = false;
+        instance.$resetting = false;
+      }))
+      .catch(action((err) => {
+        instance.$validating = false;
+        instance.$clearing = false;
+        instance.$resetting = false;
+        throw err;
+      }))
+      .then(() => instance);
   }
 
   @action


### PR DESCRIPTION
If the `throw err` in the `catch` in this promise structure executes then the outer promise would never complete. Also I am using a promise library that show warnings when promises are not explicitly completed without a `.done()`. 

This code change flattens the promise structure so that 1) errors are propagated correctly and 2) There are no 'hidden' inner promises.