### PR TITLE
Fix explicit undefined setDeep

### DIFF
--- a/src/shared/Actions.js
+++ b/src/shared/Actions.js
@@ -233,7 +233,9 @@ export default {
       // update the field/fields if defined
       if (!_.isUndefined(field)) {
         // update field values or others props
-        field.set($, $val, recursion);
+        if (!_.isUndefined($val)) {
+          field.set($, $val, recursion);
+        }
         // update values recursively only if field has nested
         if (field.fields.size && _.isObject($val)) {
           this.deepSet($, $val, $path, recursion);

--- a/tests/data/forms/nested/form.s.js
+++ b/tests/data/forms/nested/form.s.js
@@ -5,6 +5,7 @@ import { Form } from '../../../../src';
 const fields = [
   'club.name',
   'club.city',
+  'club.bouncer',
   'members',
   'members[].firstname',
   'members[].lastname',
@@ -110,6 +111,7 @@ class NewForm extends Form {
           club: {
             name: 'club-name-set-value',
             city: 'club-city-set-value',
+            bouncer: undefined,
           },
         });
 

--- a/tests/nested.values.js
+++ b/tests/nested.values.js
@@ -173,3 +173,14 @@ describe('Check Nested $Q Values after reset', () => {
   it('$Q members[1].hobbies[1] value should be equal to "Basket"', () =>
     expect($.$Q.$('members[1].hobbies[1]').value).to.be.equal('Basket'));
 });
+
+describe('Check Nested $S Values', () => {
+  it('$S club.name value should be equal to "club-name-set-value-intercepted"', () =>
+    expect($.$S.$('club.name').value).to.be.equal('club-name-set-value-intercepted'));
+
+  it('$S club.city value should be equal to "club-city-set-value"', () =>
+    expect($.$S.$('club.city').value).to.be.equal('club-city-set-value'));
+
+  it('$S club.bouncer value should be empty string', () =>
+    expect($.$S.$('club.bouncer').value).to.equal(''));
+});


### PR DESCRIPTION
The problem was, that the value was `undefined`, but the "prop" was `value`.
Because there was only one argument it set the value of the field to the prop name `"value"`.

I added a test to the `form.s` case. If this should be tested somewhere else, please give me a hint :)

closes #382 