### PR TITLE
fix parsing field names which start with a number

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -31,7 +31,7 @@ const parseInput = (input, {
 
 // make integers labels empty
 const parseGetLabel = label =>
-  _.isInteger(_.parseInt(label)) ? '' : label;
+  _.isFinite(_.toNumber(label)) ? '' : label;
 
 const parseArrayProp = ($val, $prop) => {
   const $values = _.values($val);

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,7 +146,7 @@ const allowNested = (field, strictProps) =>
     ]) || strictProps);
 
 const parseIntKeys = fields =>
-  _.map(getObservableMapKeys(fields), _.ary(parseInt, 1));
+  _.map(getObservableMapKeys(fields), _.ary(_.toNumber, 1));
 
 const hasIntKeys = fields =>
   _.every(parseIntKeys(fields), _.isInteger);


### PR DESCRIPTION
It fixes parsing field names which start with numbers

```javascript
const fields =  [{
    name: "1a",
    value: " "
  },  {
    name: "2a",
    value: " "
  },  {
    name: "3a",
    value: " "
 }]
```

Actual result
```javascript
form.values() // [" ", " ", " "]
```

Expected result
```javascript
form.values() // {"1s": " ", "2s": " ", "3s": " "}
```

