### PR TITLE
Slightly better null checking (iOS safari issue)

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -18,7 +18,7 @@ export default class Base {
 
   execHandler = (name, args, fallback = null) => [$try(
     this.$handlers[name] && this.$handlers[name].apply(this, [this]),
-    this.handlers && this.handlers.apply(this, [this])[name].apply(this, [this]),
+    this.handlers && this.handlers.apply(this, [this])[name] && this.handlers.apply(this, [this])[name].apply(this, [this]),
     fallback,
     this.noop,
   ).apply(this, [...args]), this.execHook(name)];


### PR DESCRIPTION
It seems that on iOS Safari I am getting the following error on the line that I have edited in the PR:

Message: undefined is not a function (near '...(0,u.$try)(t.$handlers[e]&&t.$handlers[e].apply(t,[t]),t.handlers&&t.handlers.apply(t,[t])[e].apply(t,[t]),r,t.noop).apply...')

It's hard for me to nail down what the exact cause is, since this is happening on our production environments. The fact that it mentions a functions probably means that the `this.handlers` lookup is probably returning undefined.

I took a look through the code, but I couldn't see any usages of the `this.handlers`, only `this.$handlers`. I'm not really sure what the interaction is down at this level, and how iOS safari comes into play...

---

Here is the longer stack trace that I have. In this example it is on the 'onBlur' event, but I have also seen the issue on 'onFocus' and also on the Form.onSubmit call as well.

Message: undefined is not a function (near '...(0,u.$try)(t.$handlers[e]&&t.$handlers[e].apply(t,[t]),t.handlers&&t.handlers.apply(t,[t])[e].apply(t,[t]),r,t.noop).apply...')
at _this line 72, column 0 (webpack:///../client_modules/node_modules/mobx-react-form/lib/Base.js:72)
  
            &nbsp;
    this.execHandler = function (name, args) {
      var fallback = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
      return [(0, _utils.$try)(_this.$handlers[name] && _this.$handlers[name].apply(_this, [_this]), _this.handlers && _this.handlers.apply(_this, [_this])[name].apply(_this, [_this]), fallback, _this.noop).apply(_this, [].concat(_toConsumableArray(args))), _this.execHook(name)]; <---- here
    };
&nbsp;
           
at event line 271, column 0 (webpack:///../client_modules/node_modules/@material-ui/core/InputBase/InputBase.js:271)
 
      if (_this.props.onBlur) {
        _this.props.onBlur(event);  <---- here
      }
      var muiFormControl = _this.context.muiFormControl;
           
at d line 16, column 183 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:16)
at f line 16, column 240 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:16)
at Array line 17, column 392 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:17)
at a line 18, column 19 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:18)
at call line 19, column 62 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:19)
at _dispatchInstances line 18, column 289 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:18)
at line 21, column 352 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:21)
at line 86, column 0 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:86)
at W line 216, column 462 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:216)
at nodeName line 39, column 366 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:39)
at call line 87, column 15 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:87)
at context line 217, column 131 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:217)
at ancestors line 86, column 188 (webpack:///../client_modules/node_modules/react-dom/cjs/react-dom.production.min.js:86)
at Tn line , column ([native code]:0)
at dispatchEvent line , column ([native code]:0)
at ? line , column ([native code]:0)
