### PR TITLE
feat: Added submitCount to form to track number of submission attempts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+1. Fork the repository
+2. Make applicable changes (with tests!)
+3. To run tests: `yarn test`
+4. Ensure builds succeed: `yarn run build`
+5. Commit via yarn to run pre-commit checks: `yarn run commit`

--- a/src/Form.js
+++ b/src/Form.js
@@ -16,6 +16,7 @@ export default class Form extends Base {
   $handlers = {};
 
   @observable $submitting = false;
+  @observable $submitCount = 0;
   @observable $validating = false;
 
   @observable fields = observable.map ? observable.map({}) : asMap({});
@@ -75,6 +76,10 @@ export default class Form extends Base {
 
   /* ------------------------------------------------------------------ */
   /* COMPUTED */
+
+  @computed get hasSubmitted() {
+    return this.$submitCount > 0;
+  }
 
   @computed get submitting() {
     return this.$submitting;
@@ -191,6 +196,7 @@ export const prototypes = {
   @action reset() {
     this.$touched = false;
     this.$changed = false;
+    this.$submitCount = 0;
     this.each(field => field.reset(true));
   },
 

--- a/src/shared/Actions.js
+++ b/src/shared/Actions.js
@@ -19,6 +19,9 @@ export default {
   @action
   submit(o = {}) {
     this.$submitting = true;
+    if (_.has(this, '$submitCount')) {
+      this.$submitCount += 1;
+    }
 
     const exec = isValid => isValid
       ? this.execHook('onSuccess', o)

--- a/tests/fixes.submit.js
+++ b/tests/fixes.submit.js
@@ -19,6 +19,9 @@ describe('Form submit() decoupled callback', () => {
 
           it('$L email hasError should be true', () =>
             expect(form.$('email').hasError).to.be.true);
+
+          it('$L form submitCount should be 1', () =>
+            expect(form.$submitCount).to.equal(1));
         });
 
         // eslint-disable-next-line

--- a/tests/flat.submit.js
+++ b/tests/flat.submit.js
@@ -7,6 +7,7 @@ describe('Form submit() decoupled callback', () => {
   it('$I.submit() should call onSuccess callback on valid form', (done) => {
     $.$I.submit({
       onSuccess: (form) => {
+        expect(form.$submitCount).to.equal(1);
         expect(form.isValid).to.be.true; // eslint-disable-line
         done();
       },
@@ -17,6 +18,7 @@ describe('Form submit() decoupled callback', () => {
   it('$N.submit() should call onError callback on invalid form', (done) => {
     $.$N.submit({
       onError: (form) => {
+        expect(form.$submitCount).to.equal(1);
         expect(form.isValid).to.be.false; // eslint-disable-line
         done();
       },


### PR DESCRIPTION
Added submitCount to form to track number of submission attempts with a computed to determine
whether or not the form has been submitted yet.

I didn't add any tests for resetting 'cause there didn't seem to be any. Additionally, I was unable to figure how to make the `$submitCount` change unique to `Form.js` instead of being in `Actions.js` without breaking everything.