### PR TITLE
feat: Additional validation hook (on change after blur)

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -81,6 +81,7 @@ export default class Field extends Base {
   @observable $focused = false;
   @observable $touched = false;
   @observable $changed = false;
+  @observable $hasBlurred = false;
 
   @observable $submitting = false;
   @observable $validating = false;
@@ -292,6 +293,12 @@ export default class Field extends Base {
       : this.$focused;
   }
 
+  @computed get hasBlurred() {
+    return this.hasNestedFields
+      ? this.check('hasBlurred', true)
+      : this.$hasBlurred;
+  }
+
   @computed get touched() {
     return this.hasNestedFields
       ? this.check('touched', true)
@@ -342,6 +349,10 @@ export default class Field extends Base {
   onBlur = (...args) =>
     this.execHandler('onBlur', args,
       action(() => {
+        if (!this.$hasBlurred) {
+          this.$hasBlurred = true;
+        }
+
         this.$focused = false;
       }));
 
@@ -517,6 +528,7 @@ export const prototypes = {
     this.$clearing = true;
     this.$touched = false;
     this.$changed = false;
+    this.$hasBlurred = false;
 
     this.$value = defaultClearValue({ value: this.$value });
     this.files = undefined;
@@ -533,6 +545,7 @@ export const prototypes = {
     this.$resetting = true;
     this.$touched = false;
     this.$changed = false;
+    this.$hasBlurred = false;
 
     const useDefaultValue = (this.$default !== this.$initial);
     if (useDefaultValue) this.value = this.$default;
@@ -588,6 +601,14 @@ export const prototypes = {
           this.debouncedValidation({
             showErrors: opt.get('showErrorsOnChange', this),
           }));
+    } else if (opt.get('validateOnChangeAfterInitialBlur', this)) {
+      this.disposeValidationOnChange = observe(this, '$value', () => (
+        !this.actionRunning &&
+        this.hasBlurred &&
+        this.debouncedValidation({
+          showErrors: opt.get('showErrorsOnChange', this),
+        })
+      ));
     }
   },
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -17,6 +17,7 @@ export default class Options {
     validateOnInit: true,
     validateOnBlur: true,
     validateOnChange: false,
+    validateOnChangeAfterInitialBlur: false,
     validateDisabledFields: false,
     strictUpdate: false,
     strictDelete: true,


### PR DESCRIPTION
Created validateOnChangeAfterInitialBlur, which will validate the field onChange, but only if the
field has been blurred at least once.

![demo](https://user-images.githubusercontent.com/5009136/49045123-f78a5e00-f19d-11e8-9bb0-995993041ca9.gif)
