### PR TITLE
Added opencollective dep within prod dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     }
   },
   "dependencies": {
+    "opencollective": "^1.0.3",
     "lodash": "^4.16.2"
   },
   "peerDependencies": {
@@ -97,7 +98,6 @@
     "mocha": "3.2.0",
     "npm-run-all": "4.0.1",
     "nyc": "^10.2.0",
-    "opencollective": "^1.0.3",
     "replace": "^0.3.0",
     "rimraf": "2.5.4",
     "semantic-release": "^15.8.1",


### PR DESCRIPTION
Hi Claudio,

I have seen that your latest release #1.35.2 is breaking the build because of the `postinstall` script misses the `opencollective` dependencies.
I have moved the `opencollective` dep within the prod dependencies.

Hope it helps
Mattia