### PR TITLE
Add Option to Skip Validation of Pristine Fields

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -18,6 +18,7 @@ export default class Options {
     validateOnBlur: true,
     validateOnChange: false,
     validateDisabledFields: false,
+    validatePristineFields: true,
     strictUpdate: false,
     strictDelete: true,
     retrieveOnlyDirtyValues: false,

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -100,6 +100,8 @@ export default class Validator {
     if (!instance.path) throw new Error('Validation Error: Invalid Field Instance');
     // do not validate disabled fields
     if (instance.disabled && !this.form.state.options.get('validateDisabledFields')) return;
+    // do not validate pristine fields
+    if (instance.isPristine && !this.form.state.options.get('validatePristineFields')) return;
     // reset field validation
     instance.resetValidation();
     // validate with all drivers


### PR DESCRIPTION
This PR adds a new option `validatePristineFields` which when set to `false` will skip validation on fields that have not been changed.  I'm not sure if this will be useful for others but our application has some large forms which may be instantiated with missing data for some required fields.  In this case, we don't want to prevent the form from being submitted. 