### PR TITLE
feat: Added new validation callback, validateOnChangeAfterInitialBlur

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -81,7 +81,7 @@ export default class Field extends Base {
   @observable $focused = false;
   @observable $touched = false;
   @observable $changed = false;
-  @observable $hasBlurred = false;
+  @observable $blurred = false;
 
   @observable $submitting = false;
   @observable $validating = false;
@@ -293,10 +293,10 @@ export default class Field extends Base {
       : this.$focused;
   }
 
-   @computed get hasBlurred() {
+  @computed get blurred() {
     return this.hasNestedFields
-      ? this.check('hasBlurred', true)
-      : this.$hasBlurred;
+      ? this.check('blurred', true)
+      : this.$blurred;
   }
 
   @computed get touched() {
@@ -349,8 +349,8 @@ export default class Field extends Base {
   onBlur = (...args) =>
     this.execHandler('onBlur', args,
       action(() => {
-        if (!this.$hasBlurred) {
-          this.$hasBlurred = true;
+        if (!this.$blurred) {
+          this.$blurred = true;
         }
 
         this.$focused = false;
@@ -528,7 +528,7 @@ export const prototypes = {
     this.$clearing = true;
     this.$touched = false;
     this.$changed = false;
-    this.$hasBlurred = false;
+    this.$blurred = false;
 
     this.$value = defaultClearValue({ value: this.$value });
     this.files = undefined;
@@ -545,7 +545,7 @@ export const prototypes = {
     this.$resetting = true;
     this.$touched = false;
     this.$changed = false;
-    this.$hasBlurred = false;
+    this.$blurred = false;
 
     const useDefaultValue = (this.$default !== this.$initial);
     if (useDefaultValue) this.value = this.$default;
@@ -604,7 +604,7 @@ export const prototypes = {
     } else if (opt.get('validateOnChangeAfterInitialBlur', this)) {
       this.disposeValidationOnChange = observe(this, '$value', () => (
         !this.actionRunning &&
-        this.hasBlurred &&
+        this.blurred &&
         this.debouncedValidation({
           showErrors: opt.get('showErrorsOnChange', this),
         })

--- a/src/Options.js
+++ b/src/Options.js
@@ -17,6 +17,7 @@ export default class Options {
     validateOnInit: true,
     validateOnBlur: true,
     validateOnChange: false,
+    validateOnChangeAfterInitialBlur: false,
     validateDisabledFields: false,
     validatePristineFields: true,
     strictUpdate: false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { values as mobxValues, keys as mobxKeys } from 'mobx3';
 
 const props = {
-  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing', 'hasBlurred'],
+  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing', 'blurred'],
   field: ['value', 'initial', 'default', 'label', 'placeholder', 'disabled', 'related', 'options', 'extra', 'bindings', 'type', 'hooks', 'handlers', 'error'],
   separated: ['values', 'initials', 'defaults', 'labels', 'placeholders', 'disabled', 'related', 'options', 'extra', 'bindings', 'types', 'hooks', 'handlers'],
   handlers: ['onChange', 'onToggle', 'onFocus', 'onBlur', 'onDrop', 'onSubmit', 'onReset', 'onClear', 'onAdd', 'onDel'],
@@ -16,7 +16,7 @@ const props = {
     isEmpty: 'every',
     hasError: 'some',
     focused: 'some',
-    hasBlurred: 'some',
+    blurred: 'some',
     touched: 'some',
     changed: 'some',
     disabled: 'every',

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { values as mobxValues, keys as mobxKeys } from 'mobx3';
 
 const props = {
-  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing'],
+  booleans: ['hasError', 'isValid', 'isDirty', 'isPristine', 'isDefault', 'isEmpty', 'focused', 'touched', 'changed', 'disabled', 'resetting', 'clearing', 'hasBlurred'],
   field: ['value', 'initial', 'default', 'label', 'placeholder', 'disabled', 'related', 'options', 'extra', 'bindings', 'type', 'hooks', 'handlers', 'error'],
   separated: ['values', 'initials', 'defaults', 'labels', 'placeholders', 'disabled', 'related', 'options', 'extra', 'bindings', 'types', 'hooks', 'handlers'],
   handlers: ['onChange', 'onToggle', 'onFocus', 'onBlur', 'onDrop', 'onSubmit', 'onReset', 'onClear', 'onAdd', 'onDel'],
@@ -16,6 +16,7 @@ const props = {
     isEmpty: 'every',
     hasError: 'some',
     focused: 'some',
+    hasBlurred: 'some',
     touched: 'some',
     changed: 'some',
     disabled: 'every',


### PR DESCRIPTION
Added new validation callback, validateOnChangeAfterInitialBlur. With this option, validation occurs
on blur, and on change after the field has been blurred once. If the field has not blurred,
validation does not occur on change.