### PR TITLE
Make mobx-react-form compatible with MobX 6.1

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -15,9 +15,6 @@ export default class Form extends Base {
   $hooks = {};
   $handlers = {};
 
-  @observable $submitting = false;
-  @observable $validating = false;
-
   @observable fields = observable.map ? observable.map({}) : asMap({});
 
   constructor(setup = {}, {


### PR DESCRIPTION
In MobX 6.1 `Attempt to re-annotate property always throws. Previously mostly undefined outcome.` https://github.com/mobxjs/mobx/releases#:~:text=Attempt%20to%20re-annotate%20property%20always%20throws.%20Previously%20mostly%20undefined%20outcome.

The `$submitting` and `$validating` properties are defined in `Base` (https://github.com/foxhound87/mobx-react-form/blob/master/src/Base.js#L13 + https://github.com/foxhound87/mobx-react-form/blob/master/src/Base.js#L16), so we have to remove this properties from `Form`, because of the error:
```
Error: [MobX] Cannot apply '@observable' to 'Form.prototype.$submitting':
The field is already decorated with '@observable'.
Re-decorating fields is not allowed.
Use '@override' decorator for methods overriden by subclass.
```
Fixes #569.