### PR TITLE
Get rid of erroneous configure function call in entry point

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import { configure } from 'mobx';
-
 import Form, { prototypes as formPrototypes } from './Form';
 import Field, { prototypes as fieldPrototypes } from './Field';
 
@@ -9,16 +7,6 @@ import fieldHelpers from './shared/Helpers';
 import fieldActions from './shared/Actions';
 import fieldUtils from './shared/Utils';
 import fieldEvents from './shared/Events';
-
-/**
-  Enables MobX strict mode globally (TEST only).
-  - - - - - - - - - - - - - - - - - -
-  In strict mode, it is not allowed to
-  change any state outside of an action
-*/
-if (process.env.TEST) {
-    configure({ enforceActions: true })
-}
 
 /**
   Extend Classes with Prototype


### PR DESCRIPTION
Strict mode is enabled by default in MobX 6 https://mobx.js.org/configuration.html#enforceactions.

Actually, `configure({ enforceActions: true })` disables enabled by default strict mode in MobX 6, because `true` is converted to `false` here https://github.com/mobxjs/mobx/blob/ddf99789daebc6a891c930bf77df132d532e090f/packages/mobx/src/api/configure.ts#L39.