### PR TITLE
fix(base.ts): fix form defaults()

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -941,7 +941,7 @@ export default class Base implements BaseInterface {
     Fields Default Values (recursive with Nested Fields)
    */
   defaults() {
-    return this.get(FieldPropsEnum.placeholder);
+    return this.get(FieldPropsEnum.default);
   }
 
   /**

--- a/tests/data/_.flat.ts
+++ b/tests/data/_.flat.ts
@@ -17,6 +17,7 @@ import $O from "./forms/flat/form.o";
 import $P from "./forms/flat/form.p";
 import $Q from "./forms/flat/form.q";
 import $R from "./forms/flat/form.r";
+import $T from "./forms/flat/form.t";
 
 export default {
   $A,
@@ -35,4 +36,5 @@ export default {
   $P,
   $Q,
   $R,
+  $T,
 };

--- a/tests/data/forms/flat/form.t.ts
+++ b/tests/data/forms/flat/form.t.ts
@@ -1,0 +1,34 @@
+import { Form } from "../../../../src";
+
+const fields = ["username", "email", "country"];
+
+const values = {
+  username: "",
+  email: "",
+  country: "",
+};
+
+const defaults = {
+  username: "TestUser",
+  email: "s.jobs@apple.com",
+  country: "USA",
+};
+
+const labels = {
+  username: "User name",
+  email: "Email",
+  country: "Country",
+};
+
+class NewForm extends Form {
+}
+
+export default new NewForm(
+  {
+    fields,
+    values,
+    defaults,
+    labels,
+  },
+  { name: "Flat-T" }
+);

--- a/tests/flat.actions.ts
+++ b/tests/flat.actions.ts
@@ -167,3 +167,15 @@ describe('Field values type checks', () => {
     assert.isNumber($.$A.$('assets').value,
       '$A assets.value is not a number'));
 });
+
+describe('Form default values', () => {
+  it('$T defaults is an object', () =>
+    assert.isObject($.$T.defaults(),
+      '$T defaults is not an object'));
+
+  it('$T defaults check default field values', () => {
+    expect($.$T.defaults().username).to.be.equal('TestUser');
+    expect($.$T.defaults().email).to.be.equal('s.jobs@apple.com');
+    expect($.$T.defaults().country).to.be.equal('USA');
+  });
+});


### PR DESCRIPTION
It seems to me, that there was a bug introduced with commit https://github.com/foxhound87/mobx-react-form/commit/26123aa7718871c6e9ddec67e1699e949d096ece#diff-65addcde6fff5229abdf5708736cabd07f335e865002080cd102d2fbb3ec67a8R865.

Today I have updated `mobx-react-form` in my project from version 3.2.0 to 6.1.0 and noticed a problem with default values, which now became an empty object. After digging in lib code I have found the culprit in the commit mentioned above.

My form was defined like this (simplified):

```
const fields = ['type', 'from', 'to'];
const defaults = {
  type: 'INVOICES',
  from: '2023-01-01',
  to: '2023-12-31',
};

class ReportingForm extends Form {}

export default new ReportingForm({ fields, defaults });
```

and running following code:
```
const defaults = ReportingForm.defaults();
```
returned an empty object.