### PR TITLE
Add sponsor svg image to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,15 +189,4 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/mobx-react-form#sponsor)]
 
-<a href="https://opencollective.com/mobx-react-form/sponsor/0/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/1/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/2/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/3/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/4/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/5/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/6/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/7/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/8/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/mobx-react-form/sponsor/9/website" target="_blank"><img src="https://opencollective.com/mobx-react-form/sponsor/9/avatar.svg"></a>
-
-
+<img src="https://opencollective.com/mobx-react-form/sponsors.svg"/>


### PR DESCRIPTION
Proposing changes to simplify the svg imports from Open Collective as discussed in https://opencollective.freshdesk.com/a/tickets/231872