### PR TITLE
fix: #632 assignable hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.7.1 (master)
+- Fix: #632 observable hooks and handlers
+
 # 6.7.0 (master)
 - Feat: introduced `class`/`classes` props to handle `Field` extension in Fields Definitions.
 

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -73,6 +73,8 @@ export default class Base implements BaseInterface {
       $resetting: observable,
       $touched: observable,
       $changed: observable,
+      $hooks: observable,
+      $handlers: observable,
       changed: computed,
       submitted: computed,
       submitting: computed,


### PR DESCRIPTION
https://github.com/foxhound87/mobx-react-form/issues/632

This bug was introduced in v6.4.0

In rare circumstances, creating a form class with a hooks method can
cause the first trigger of the hook to fail.

Example:

```
import { Form } from "mobx-react-form";
import { makeObservable, flow } from "mobx";

let x = 0;

class HookedForm extends Form {
  constructor() {
    super({ fields: ["aField"] });
    makeObservable(this, {
      onSuccess: flow,
    });
  }

  hooks() {
    return { onSuccess: this.onSuccess };
  }

  *onSuccess() {
    alert(`onSuccess ${++x}`);
  }
}

export default function App() {
  return (
    <div className="App">
      <button onClick={() => new HookedForm().submit()}>Test</button>
    </div>
  );
}
```

Change the hook and handler objects to shallow observables, which
prevents this problem.
