### PR TITLE
poc - remove lodash head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.7.1 (master)
+- Fix: #632 observable hooks and handlers
+
 # 6.7.0 (master)
 - Feat: introduced `class`/`classes` props to handle `Field` extension in Fields Definitions.
 

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -73,6 +73,8 @@ export default class Base implements BaseInterface {
       $resetting: observable,
       $touched: observable,
       $changed: observable,
+      $hooks: observable,
+      $handlers: observable,
       changed: computed,
       submitted: computed,
       submitting: computed,

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -812,7 +812,9 @@ export default class Field extends Base implements FieldInterface {
 
   showErrors(show: boolean = true): void {
     this.showError = show;
-    this.errorSync = _.head(this.validationErrorStack) as string;
+    // console.debug("constructor", this.validationErrorStack.constructor.name)
+    // console.debug("length", this.validationErrorStack?.length)
+    this.errorSync = (this.validationErrorStack.length ? this.validationErrorStack[0] : "") as string;
     this.each((field: any) => field.showErrors(show));
   }
 

--- a/tests/test.fieldClass.ts
+++ b/tests/test.fieldClass.ts
@@ -1,4 +1,5 @@
-import { Field } from "../src";
+import { Form, Field } from "../src";
+import vjf from "../src/validators/VJF";
 import {
   $OVERRIDE,
   $SEPARATED,
@@ -67,5 +68,15 @@ describe("FieldClass", () => {
         OverrideCustomField,
       );
     });
+  });
+});
+
+describe.only("head", () => {
+  it("doesn't break", () => {
+    // new Form({ fields: ["test"] }).submit({ showErrors: true });
+    new Form(
+      { fields: { name: "test", validators: [() => [true]] } },
+      { plugins: { vjf: vjf() } },
+    ).submit({ showErrors: true });
   });
 });


### PR DESCRIPTION
Removing lodash `head` from Field causes a mobx warning. It's a known
function of mobx that it will consider 0 index of an empty array as out of
bounds (which is actually correct) but JS will return `undefined`. For
our case, we can avoid it entirely by checking if it's empty before
accessing it, which is part of how lodash's head is implemented.

lodash's head implementation with length check:

```
function head(array) {
    return array != null && array.length ? array[0] : undefined;
}
```

It is not something that they plan to change in Mobx. Instead, there is
a flag to turn off the warning in production, should we choose to simply
ignore the warning and try to access anything in the empty array.

@see https://github.com/mobxjs/mobx/issues/2913
