### PR TITLE
Prototype for ‘custom’ field type

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -593,6 +593,11 @@ export default class Base implements BaseInterface {
     Set Fields Props
    */
   set(prop: any, data?: any): void {
+    if (_.isString(prop) && prop === FieldPropsEnum.value && (this as any).type === "custom") {
+      (this as any).value = data;
+      return;
+    }
+
     // UPDATE CUSTOM PROP
     if (_.isString(prop) && !_.isUndefined(data)) {
       allowedProps(AllowedFieldPropsTypes.editable, [prop]);

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -439,12 +439,12 @@ export default class Field extends Base implements FieldInterface {
 
   get isDirty(): boolean {
     const value = this.changed ? this.value : this.initial;
-    return !_.isNil(this.initial) && !_.isEqual(this.initial, value);
+    return !_.isEqual(this.initial, value);
   }
 
   get isPristine(): boolean {
     const value = this.changed ? this.value : this.initial;
-    return !_.isNil(this.initial) && _.isEqual(this.initial, value);
+    return _.isEqual(this.initial, value);
   }
 
   get isEmpty(): boolean {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,6 +16,7 @@ const defaultValue = ({
   isEmptyArray = false,
   fallbackValueOption = "",
 }: any): null | false | 0 | [] | "" => {
+  if (type === "custom") return undefined; // TODO: might want to provide a way to set a custom default value
   if (Array.isArray(value) || isEmptyArray) return [];
   if (_.isDate(value) || type === "date" || type === "datetime-local") return null;
   if (_.isNumber(value) || type === "number") return 0;

--- a/tests/data/_.fixes.ts
+++ b/tests/data/_.fixes.ts
@@ -27,6 +27,7 @@ import $U from "./forms/fixes/form.u";
 import $V from "./forms/fixes/form.v";
 import $Z from "./forms/fixes/form.z";
 
+import $167 from "./forms/fixes/form.167";
 import $425 from "./forms/fixes/form.425";
 import $472 from "./forms/fixes/form.472";
 import $480 from "./forms/fixes/form.480";
@@ -72,6 +73,7 @@ export default {
   $V,
   $Z,
 
+  $167,
   $425,
   $472,
   $480,

--- a/tests/data/forms/fixes/form.167.ts
+++ b/tests/data/forms/fixes/form.167.ts
@@ -1,0 +1,130 @@
+import { expect } from "chai";
+import { Form } from "../../../../src";
+import FormInterface from "../../../../src/models/FormInterface";
+
+export default new Form(
+  {
+    fields: ["custom"],
+    values: {
+      custom: null,
+    },
+    initials: {
+      custom: null,
+    },
+    defaults: {
+      custom: null,
+    },
+    types: {
+      custom: "custom",
+    },
+  },
+  {
+    name: "Fixes-A1",
+    hooks: {
+      onInit(form: FormInterface) {
+        describe("Check initial values state:", () => {
+          // test form
+          it("form $A1 isDirty should be false", () => expect(form.isDirty).to.be.false);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.true);
+
+          // test field
+          it("form $A1 custom isDirty should be false", () => expect(form.$("custom").isDirty).to.be.false);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.true);
+          it("form $A1 custom value should be null", () => expect(form.$("custom").value).to.be.null);
+        });
+
+        describe("Check custom field value change:", () => {
+          before(() => form.$("custom").set(""));
+
+          // test form
+          it("form $A1 isDirty should be true", () => expect(form.isDirty).to.be.true);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.false);
+
+          // test field
+          it("form $A1 custom isDirty should be true", () => expect(form.$("custom").isDirty).to.be.true);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.false);
+          it("form $A1 custom value should be empty", () => expect(form.$("custom").value).to.eq(""));
+        });
+
+        describe("Check manually setting null value:", () => {
+          before(() => form.$("custom").set(null));
+
+          // test form
+          it("form $A1 isDirty should be false", () => expect(form.isDirty).to.be.false);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.true);
+
+          // test field
+          it("form $A1 custom isDirty should be false", () => expect(form.$("custom").isDirty).to.be.false);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.true);
+          it("form $A1 custom value should be null", () => expect(form.$("custom").value).to.be.null);
+        });
+
+        describe("Check clearing form:", () => {
+          before(() => {
+            form.$("custom").set("test"); // set value to test clear working properly
+            expect(form.$("custom").value).to.eq("test");
+
+            form.clear();
+          });
+
+          // test form
+          it("form $A1 isDirty should be false", () => expect(form.isDirty).to.be.false);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.true);
+
+          // test field
+          it("form $A1 custom isDirty should be false", () => expect(form.$("custom").isDirty).to.be.false);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.true);
+          it("form $A1 custom value should be null", () => expect(form.$("custom").value).to.be.undefined);
+        });
+
+        describe("Check resetting form:", () => {
+          before(() => {
+            form.$("custom").set("test"); // set value to test clear working properly
+            expect(form.$("custom").value).to.eq("test");
+
+            form.reset();
+          })
+
+          // test form
+          it("form $A1 isDirty should be false", () => expect(form.isDirty).to.be.false);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.true);
+
+          // test field
+          it("form $A1 custom isDirty should be false", () => expect(form.$("custom").isDirty).to.be.false);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.true);
+          it("form $A1 custom value should be null", () => expect(form.$("custom").value).to.be.null);
+        });
+
+        describe("Check explicitly setting value:", () => {
+          before(() => {
+            form.$("custom").set("value", "test");
+          })
+
+          // test form
+          it("form $A1 isDirty should be true", () => expect(form.isDirty).to.be.true);
+          it("form $A1 isPristine should be false", () => expect(form.isPristine).to.be.false);
+
+          // test field
+          it("form $A1 custom isDirty should be true", () => expect(form.$("custom").isDirty).to.be.true);
+          it("form $A1 custom isPristine should be false", () => expect(form.$("custom").isPristine).to.be.false);
+          it("form $A1 custom value should be `test`", () => expect(form.$("custom").value).to.be.eq("test"));
+        });
+
+        describe("Check explicity setting value to null:", () => {
+          before(() => {
+            form.$("custom").set("value", null);
+          })
+          
+          // test form
+          it("form $A1 isDirty should be false", () => expect(form.isDirty).to.be.false);
+          it("form $A1 isPristine should be true", () => expect(form.isPristine).to.be.true);
+
+          // test field
+          it("form $A1 custom isDirty should be false", () => expect(form.$("custom").isDirty).to.be.false);
+          it("form $A1 custom isPristine should be true", () => expect(form.$("custom").isPristine).to.be.true);
+          it("form $A1 custom value should be null", () => expect(form.$("custom").value).to.be.null);
+        })
+      },
+    },
+  }
+);

--- a/tests/fixes.values.ts
+++ b/tests/fixes.values.ts
@@ -815,3 +815,47 @@ describe('$V Field values checks', () => {
   it('$V pieces[1].width values to be not equal zero', () => expect($.$V.$('pieces[1].width').value).to.be.not.equal(0));
   it('$V pieces[1].height values to be not equal zero', () => expect($.$V.$('pieces[1].height').value).to.be.not.equal(0));
 });
+
+// issue #167
+describe("#167, null as default value", () => {
+  it("maintains null value on reset", () => {
+    const form = new Form({
+      fields: {
+        customField: {
+          value: null,
+          type: "custom", // use "custom" type to allow null/undefined values
+        },
+      },
+    });
+
+    // Initial state check
+    expect(form.$("customField").value).to.be.equal(null);
+    expect(form.$("customField").initial).to.be.equal(null);
+    expect(form.$("customField").default).to.be.equal(null);
+    expect(form.$("customField").isDirty).to.be.false;
+    expect(form.$("customField").isPristine).to.be.true;
+
+    // Change the value
+    form.$("customField").set("some custom value");
+    expect(form.$("customField").value).to.be.equal("some custom value");
+    expect(form.$("customField").initial).to.be.equal(null);
+    expect(form.$("customField").default).to.be.equal(null);
+    expect(form.$("customField").isDirty).to.be.true;
+    expect(form.$("customField").isPristine).to.be.false;
+
+    // Reset the form
+    form.reset();
+
+    // After reset, the field should maintain null value
+    expect(form.$("customField").value).to.be.equal(null);
+    expect(form.$("customField").initial).to.be.equal(null);
+    expect(form.$("customField").default).to.be.equal(null);
+    expect(form.$("customField").isDirty).to.be.false;
+    expect(form.$("customField").isPristine).to.be.true;
+
+    // Additional check to ensure isDirty works correctly with empty string
+    form.$("customField").set("");
+    expect(form.$("customField").isDirty).to.be.true; // Should be dirty since "" !== null
+    expect(form.$("customField").isPristine).to.be.false;
+  });
+});


### PR DESCRIPTION
This potentially fixes https://github.com/foxhound87/mobx-react-form/issues/167 (allowing for null values).

It also fixes `isDirty` / `isPristine` irregularities where `null` being compared to `""` (empty string) would falsely report that a field is not dirty when it should be / pristine when it shouldn't be. Here is reproducible demo:

https://codesandbox.io/p/sandbox/brave-solomon-4npr8m

I'm not 100% sure this solves all the issues or if a custom field type is a direction MRF wants to go, but it's an idea!