### PR TITLE
Further build modernizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
-        "@babel/core": "^7.29.0",
-        "@rollup/plugin-babel": "^7.0.0",
+        "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
@@ -27,7 +27,6 @@
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
         "ajv": "^5.2.2",
-        "babel-plugin-lodash": "^3.3.4",
         "chai": "3.5.0",
         "commitizen": "^4.3.0",
         "cross-env": "^5.1.4",
@@ -1015,28 +1014,19 @@
         "node": ">=12"
       }
     },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-7.0.0.tgz",
-      "integrity": "sha512-NS2+P7v80N3MQqehZEjgpaFb9UyX3URNMW/zvoECKGo4PY4DvJfQusTI7BX/Ks+CPvtTfk3TqcR6S9VYBi/C+A==",
+    "node_modules/@rollup/plugin-alias": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
+      "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+        "rollup": ">=4.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        },
         "rollup": {
           "optional": true
         }
@@ -1067,37 +1057,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -1206,26 +1165,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2126,10 +2065,11 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -2695,6 +2635,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/append-transform": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
@@ -2841,20 +2794,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
       }
     },
     "node_modules/balanced-match": {
@@ -4925,6 +4864,24 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -6828,10 +6785,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -7172,6 +7129,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -11111,12 +11081,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -11530,6 +11501,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11635,13 +11619,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -11792,13 +11769,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -14452,15 +14422,12 @@
         "config-chain": "^1.1.11"
       }
     },
-    "@rollup/plugin-babel": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-7.0.0.tgz",
-      "integrity": "sha512-NS2+P7v80N3MQqehZEjgpaFb9UyX3URNMW/zvoECKGo4PY4DvJfQusTI7BX/Ks+CPvtTfk3TqcR6S9VYBi/C+A==",
+    "@rollup/plugin-alias": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
+      "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
       "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      }
+      "requires": {}
     },
     "@rollup/plugin-commonjs": {
       "version": "29.0.2",
@@ -14475,21 +14442,6 @@
         "is-reference": "1.2.1",
         "magic-string": "^0.30.3",
         "picomatch": "^4.0.2"
-      },
-      "dependencies": {
-        "fdir": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
-        }
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -14543,20 +14495,6 @@
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
         "picomatch": "^4.0.2"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-          "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
-        }
       }
     },
     "@rollup/rollup-android-arm-eabi": {
@@ -15128,9 +15066,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
     "@types/json-schema": {
@@ -15516,6 +15454,12 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
         }
       }
     },
@@ -15627,19 +15571,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
-    },
-    "babel-plugin-lodash": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -17165,6 +17096,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "requires": {}
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -18555,10 +18493,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -18817,6 +18754,14 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
+        }
       }
     },
     "mime": {
@@ -21555,9 +21500,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true
     },
     "pkg-conf": {
@@ -21860,6 +21805,14 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -21939,12 +21892,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "require-package-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
       "dev": true
     },
     "resolve": {
@@ -22054,14 +22001,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "@types/estree": "1.0.8",
         "fsevents": "~2.3.2"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-          "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-          "dev": true
-        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -112,14 +112,14 @@
     }
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "mobx": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
-    "@rollup/plugin-babel": "^7.0.0",
+    "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
@@ -133,7 +133,6 @@
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "ajv": "^5.2.2",
-    "babel-plugin-lodash": "^3.3.4",
     "chai": "3.5.0",
     "commitizen": "^4.3.0",
     "cross-env": "^5.1.4",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,10 +1,11 @@
 import typescript from "@rollup/plugin-typescript";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
-import babel from "@rollup/plugin-babel";
+import alias from "@rollup/plugin-alias";
 import terser from "@rollup/plugin-terser";
 
 const external = ["mobx", /^lodash(\/|$)/];
+const esmExternal = ["mobx", /^lodash-es(\/|$)/];
 const umdExternal = ["mobx", "lodash"];
 const umdGlobals = { mobx: "mobx", lodash: "_" };
 
@@ -12,10 +13,8 @@ const tsOptions = (outDir, extra = {}) => ({
   compilerOptions: { module: "esnext", declaration: false, declarationMap: false, outDir, ...extra },
 });
 
-const babelPlugin = babel({
-  babelHelpers: "bundled",
-  plugins: ["lodash"],
-  extensions: [".ts"],
+const lodashToEsm = alias({
+  entries: [{ find: /^lodash$/, replacement: "lodash-es" }],
 });
 
 const libEntries = [
@@ -54,10 +53,7 @@ export default [
     },
     external,
     plugins: [
-      resolve(),
-      commonjs(),
       typescript(tsOptions("lib", { declaration: true, declarationMap: true, declarationDir: "lib" })),
-      babelPlugin,
     ],
   },
 
@@ -71,8 +67,8 @@ export default [
       preserveModulesRoot: "src",
       sourcemap: true,
     },
-    external,
-    plugins: [resolve(), commonjs(), typescript(tsOptions("lib/esm")), babelPlugin],
+    external: esmExternal,
+    plugins: [lodashToEsm, typescript(tsOptions("lib/esm"))],
   },
 
   // UMD (dev + min)

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -8,7 +8,7 @@ import {
   intercept,
   ObservableMap,
 } from "mobx";
-import _ from "lodash";
+import { each, forIn, get, has, head, isNil, isNull, isObject, isPlainObject, isString, isUndefined, last, map, max, merge, set, split, transform, trim, trimStart } from "lodash";
 import { BaseInterface } from "./models/BaseInterface";
 import { StateInterface } from "./models/StateInterface";
 import { FieldInterface } from "./models/FieldInterface";
@@ -160,7 +160,7 @@ export default abstract class Base implements BaseInterface {
   }
 
   get changed(): number {
-    return !_.isNil(this.path) && this.hasNestedFields
+    return !isNil(this.path) && this.hasNestedFields
       ? this.reduce(
           (acc: number, field: FieldInterface) => acc + field.changed,
           0
@@ -244,17 +244,17 @@ export default abstract class Base implements BaseInterface {
   */
   initFields(initial: any, update: boolean = false): void {
     const fallback = this.state.options.get(OptionsEnum.fallback);
-    const $path = (key: string) => _.trimStart([this.path, key].join("."), ".");
+    const $path = (key: string) => trimStart([this.path, key].join("."), ".");
 
     let fields;
     fields = prepareFieldsData(initial, this.state.strict, fallback);
     fields = mergeSchemaDefaults(fields, (this as any).validator);
 
     // create fields
-    _.forIn(fields, (field, key) => {
+    forIn(fields, (field, key) => {
       const path = $path(key);
       const $f = this.select(path, null, false);
-      if (_.isNil($f)) {
+      if (isNil($f)) {
         if (fallback) {
           this.initField(key, path, field, update);
         } else {
@@ -286,7 +286,7 @@ export default abstract class Base implements BaseInterface {
     const struct = pathToStruct(path);
     // try to get props from separated objects
     const _try = (prop: string) => {
-      const t = _.get(initial[prop], struct);
+      const t = get(initial[prop], struct);
       if (
         (
           [
@@ -303,7 +303,7 @@ export default abstract class Base implements BaseInterface {
     };
 
     const props = {
-      $value: _.get(initial[SeparatedPropsMode.values], path),
+      $value: get(initial[SeparatedPropsMode.values], path),
       $computed: _try(SeparatedPropsMode.computed),
       $label: _try(SeparatedPropsMode.labels),
       $placeholder: _try(SeparatedPropsMode.placeholders),
@@ -356,7 +356,7 @@ export default abstract class Base implements BaseInterface {
   */
 
   validate(opt?: ValidateOptions, obj?: ValidateOptions): Promise<any> {
-    const $opt = _.merge(opt, { path: this.path });
+    const $opt = merge(opt, { path: this.path });
     return this.state.form.validator.validate($opt, obj);
   }
 
@@ -439,7 +439,7 @@ export default abstract class Base implements BaseInterface {
 
   deepCheck(type: string, prop: string, fields: any): any {
     const $fields = getObservableMapValues(fields);
-    return _.transform(
+    return transform(
       $fields,
       (check: any, field: any) => {
         if (!field.fields.size || !Array.isArray(field.initial)) {
@@ -464,7 +464,7 @@ export default abstract class Base implements BaseInterface {
     OR Create Field if 'undefined'
    */
   update(fields: any): void {
-    if (!_.isPlainObject(fields)) {
+    if (!isPlainObject(fields)) {
       throw new Error("The update() method accepts only plain objects.");
     }
 
@@ -482,9 +482,9 @@ export default abstract class Base implements BaseInterface {
     recursion: boolean = true,
     raw?: any
   ): void {
-    _.each(fields, (field, key) => {
-      const $key = _.has(field, FieldPropsEnum.name) ? field.name : key;
-      const $path = _.trimStart(`${path}.${$key}`, ".");
+    each(fields, (field, key) => {
+      const $key = has(field, FieldPropsEnum.name) ? field.name : key;
+      const $path = trimStart(`${path}.${$key}`, ".");
 
       const strictUpdate = this.state.options.get(
         OptionsEnum.strictUpdate,
@@ -499,10 +499,10 @@ export default abstract class Base implements BaseInterface {
         this
       );
 
-      if (!_.isNil($field) && !_.isUndefined(field)) {
+      if (!isNil($field) && !isUndefined(field)) {
         if (Array.isArray($field.values())) {
           const n: number =
-            _.max(_.map(field.fields, (f, i) => Number(i))) ?? -1;
+            max(map(field.fields, (f, i) => Number(i))) ?? -1;
           getObservableMapValues($field.fields).forEach(($f) => {
             if (Number($f.name) > n) {
               $field.$changed++;
@@ -526,13 +526,13 @@ export default abstract class Base implements BaseInterface {
                   OptionsEnum.fallbackValue,
                   this
                 ),
-                separated: _.get(raw, $path),
+                separated: get(raw, $path),
               }
             );
             return;
           }
         }
-        if (_.isNull(field) || _.isNil(field.fields)) {
+        if (isNull(field) || isNil(field.fields)) {
           $field.value = parseInput(
             applyInputConverterOnUpdate ? $field.$input : (val) => val,
             {
@@ -547,15 +547,15 @@ export default abstract class Base implements BaseInterface {
         }
       }
 
-      if (!_.isNil($container) && _.isNil($field)) {
+      if (!isNil($container) && isNil($field)) {
         // get full path when using update() with select() - FIX: #179
-        const $newFieldPath = _.trimStart([this.path, $path].join("."), ".");
+        const $newFieldPath = trimStart([this.path, $path].join("."), ".");
         // init field into the container field
         $container.$changed++;
         $container.state.form.$changed++;
         $container.initField($key, $newFieldPath, field, true);
       } else if (recursion) {
-        if (_.has(field, FieldPropsEnum.fields) && !_.isNil(field.fields)) {
+        if (has(field, FieldPropsEnum.fields) && !isNil(field.fields)) {
           // handle nested fields if defined
           this.deepUpdate(field.fields, $path);
         } else {
@@ -571,7 +571,7 @@ export default abstract class Base implements BaseInterface {
     Get Fields Props
    */
   get(prop: any = null, strict: boolean = true): any {
-    if (_.isNil(prop)) {
+    if (isNil(prop)) {
       return this.deepGet(
         [...props.computed, ...props.editable, ...props.validation],
         this.fields,
@@ -584,7 +584,7 @@ export default abstract class Base implements BaseInterface {
       Array.isArray(prop) ? prop : [prop]
     );
 
-    if (_.isString(prop)) {
+    if (isString(prop)) {
       if (
         ([FieldPropsEnum.hooks, FieldPropsEnum.handlers] as string[]).includes(
           prop
@@ -626,7 +626,7 @@ export default abstract class Base implements BaseInterface {
     Get Fields Props Recursively
    */
   deepGet(prop: any, fields: any, strict = true): any {
-    return _.transform(
+    return transform(
       getObservableMapValues(fields),
       (obj: any, field: any) => {
         const $nested = ($fields: any) =>
@@ -636,7 +636,7 @@ export default abstract class Base implements BaseInterface {
           [field.key]: { fields: $nested(field.fields) },
         });
 
-        if (_.isString(prop)) {
+        if (isString(prop)) {
           const opt = this.state.options;
           const removeProp =
             (opt.get(OptionsEnum.retrieveOnlyDirtyFieldsValues, this) &&
@@ -690,7 +690,7 @@ export default abstract class Base implements BaseInterface {
           });
         }
 
-        _.each(prop, ($prop) =>
+        each(prop, ($prop) =>
           Object.assign(obj[field.key], {
             [$prop]: field[$prop],
           })
@@ -707,7 +707,7 @@ export default abstract class Base implements BaseInterface {
    */
   set(prop: any, data?: any): void {
     // UPDATE CUSTOM PROP
-    if (_.isString(prop) && !_.isUndefined(data)) {
+    if (isString(prop) && !isUndefined(data)) {
       allowedProps(AllowedFieldPropsTypes.editable, [prop]);
 
       const isPlain = (
@@ -715,8 +715,8 @@ export default abstract class Base implements BaseInterface {
       ).includes(prop);
 
       const deep: boolean =
-        (_.isObject(data) && prop === FieldPropsEnum.value) ||
-        (_.isPlainObject(data) && !isPlain);
+        (isObject(data) && prop === FieldPropsEnum.value) ||
+        (isPlainObject(data) && !isPlain);
       if (deep && this.hasNestedFields)
         return this.deepSet(prop, data, "", true);
 
@@ -738,14 +738,14 @@ export default abstract class Base implements BaseInterface {
       } else if (isPlain) {
         Object.assign(this[`$${prop}`], data);
       } else {
-        _.set(this, `$${prop}`, data);
+        set(this, `$${prop}`, data);
       }
 
       return;
     }
 
     // NO PROP NAME PROVIDED ("prop" is value)
-    if (_.isNil(data)) {
+    if (isNil(data)) {
       if (this.hasNestedFields)
         this.deepSet(FieldPropsEnum.value, prop, "", true);
       else this.set(FieldPropsEnum.value, prop);
@@ -764,7 +764,7 @@ export default abstract class Base implements BaseInterface {
     const err = "You are updating a not existent field:";
     const isStrict = this.state.options.get(OptionsEnum.strictSet, this);
 
-    if (_.isNil(data)) {
+    if (isNil(data)) {
       this.each(
         (field: any) =>
           (field.$value = defaultValue({
@@ -780,20 +780,20 @@ export default abstract class Base implements BaseInterface {
       return;
     }
 
-    _.each(data, ($val, $key) => {
-      const $path = _.trimStart(`${path}.${$key}`, ".");
+    each(data, ($val, $key) => {
+      const $path = trimStart(`${path}.${$key}`, ".");
       // get the field by path joining keys recursively
       const field = this.select($path, null, isStrict);
       // if no field found when is strict update, throw error
       if (isStrict) throwError($path, field, err);
       // update the field/fields if defined
-      if (!_.isUndefined(field)) {
+      if (!isUndefined(field)) {
         // update field values or others props
-        if (!_.isUndefined($val)) {
+        if (!isUndefined($val)) {
           field.set(prop, $val, recursion);
         }
         // update values recursively only if field has nested
-        if (field.fields.size && _.isObject($val)) {
+        if (field.fields.size && isObject($val)) {
           this.deepSet(prop, $val, $path, recursion);
         }
       }
@@ -805,7 +805,7 @@ export default abstract class Base implements BaseInterface {
    */
   add(obj: any, execEvent: boolean = true): any {
     if (isArrayOfObjects(obj)) {
-      _.each(obj, (values) =>
+      each(obj, (values) =>
         this.update({
           [maxKey(this.fields)]: values,
         })
@@ -818,16 +818,16 @@ export default abstract class Base implements BaseInterface {
     }
 
     let key;
-    if (_.has(obj, FieldPropsEnum.key)) key = obj.key;
-    if (_.has(obj, FieldPropsEnum.name)) key = obj.name;
+    if (has(obj, FieldPropsEnum.key)) key = obj.key;
+    if (has(obj, FieldPropsEnum.name)) key = obj.name;
     if (!key) key = maxKey(this.fields);
 
     const $path = ($key: string) =>
-      _.trimStart([this.path, $key].join("."), ".");
+      trimStart([this.path, $key].join("."), ".");
     const tree = pathToFieldsTree(this.state.struct(), this.path, 0, true);
-    const field = this.initField(key, $path(key), _.merge(tree[0], obj));
+    const field = this.initField(key, $path(key), merge(tree[0], obj));
     const hasValues =
-      _.has(obj, FieldPropsEnum.value) || _.has(obj, FieldPropsEnum.fields);
+      has(obj, FieldPropsEnum.value) || has(obj, FieldPropsEnum.fields);
 
     if (
       !hasValues &&
@@ -866,13 +866,13 @@ export default abstract class Base implements BaseInterface {
   del($path: string | null = null, execEvent: boolean = true) {
     const isStrict = this.state.options.get(OptionsEnum.strictDelete, this);
     const path = parsePath($path ?? this.path);
-    const fullpath = _.trim([this.path, path].join("."), ".");
+    const fullpath = trim([this.path, path].join("."), ".");
     const container = this.container($path);
-    const keys = _.split(path, ".");
-    const last = _.last(keys);
+    const keys = split(path, ".");
+    const lastKey = last(keys);
 
-    if (isStrict && !container.fields.has(last)) {
-      const msg = `Key "${last}" not found when trying to delete field`;
+    if (isStrict && !container.fields.has(lastKey)) {
+      const msg = `Key "${lastKey}" not found when trying to delete field`;
       throwError(fullpath, null, msg);
     }
 
@@ -885,7 +885,7 @@ export default abstract class Base implements BaseInterface {
 
     container.each((field) => field.debouncedValidation.cancel());
     execEvent && this.execHook(FieldPropsEnum.onDel);
-    return container.fields.delete(last);
+    return container.fields.delete(lastKey);
   }
 
   /******************************************************************
@@ -931,7 +931,7 @@ export default abstract class Base implements BaseInterface {
     }
     const $dkey = $instance.path ? `${$prop}@${$instance.path}` : $prop;
 
-    _.merge(this.state.disposers[type], {
+    merge(this.state.disposers[type], {
       [$dkey]:
         $prop === FieldPropsEnum.fields
           ? ffn.apply((change: any) => $call(change))
@@ -952,8 +952,8 @@ export default abstract class Base implements BaseInterface {
    */
   disposeAll() {
     const dispose = (disposer: any) => disposer.apply();
-    _.each(this.state.disposers.interceptor, dispose);
-    _.each(this.state.disposers.observer, dispose);
+    each(this.state.disposers.interceptor, dispose);
+    each(this.state.disposers.observer, dispose);
     this.state.disposers = { interceptor: {}, observer: {} };
     return null;
   }
@@ -978,17 +978,17 @@ export default abstract class Base implements BaseInterface {
   */
   select(path: string, fields: any = null, isStrict: boolean = true) {
     const $path = parsePath(path);
-    const keys = _.split($path, ".");
-    const head = _.head(keys);
+    const keys = split($path, ".");
+    const headKey = head(keys);
 
     keys.shift();
 
-    let $fields = _.isNil(fields) ? this.fields.get(head) : fields.get(head);
+    let $fields = isNil(fields) ? this.fields.get(headKey) : fields.get(headKey);
 
     let stop = false;
-    _.each(keys, ($key) => {
+    each(keys, ($key) => {
       if (stop) return;
-      if (_.isNil($fields)) {
+      if (isNil($fields)) {
         $fields = undefined;
         stop = true;
       } else {
@@ -1008,9 +1008,9 @@ export default abstract class Base implements BaseInterface {
    */
   container($path: string) {
     const path = parsePath($path ?? this.path);
-    const cpath = _.trim(path.replace(new RegExp("[^./]+$"), ""), ".");
+    const cpath = trim(path.replace(new RegExp("[^./]+$"), ""), ".");
 
-    if (!!this.path && _.isNil($path)) {
+    if (!!this.path && isNil($path)) {
       return cpath !== ""
         ? this.state.form.select(cpath, null, false)
         : this.state.form;

--- a/src/Bindings.ts
+++ b/src/Bindings.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { each, get, has, isPlainObject, merge } from "lodash";
 import { $try } from "./utils";
 
 import { FieldPropsEnum, FieldPropsType } from "./models/FieldProps";
@@ -33,9 +33,9 @@ export default class Bindings implements BindingsInterface {
   };
 
   register(bindings: FieldPropsType): Bindings {
-    _.each(bindings, (val, key) => {
-      if ((typeof val === 'function')) _.merge(this.templates, { [key]: val });
-      if (_.isPlainObject(val)) _.merge(this.rewriters, { [key]: val });
+    each(bindings, (val, key) => {
+      if ((typeof val === 'function')) merge(this.templates, { [key]: val });
+      if (isPlainObject(val)) merge(this.rewriters, { [key]: val });
     });
 
     return this;
@@ -43,27 +43,27 @@ export default class Bindings implements BindingsInterface {
 
   load(field: any, name: string = FieldPropsEnum.default, props: FieldPropsType) {
     const args = ({
-      keys: _.get(this.rewriters, FieldPropsEnum.default),
+      keys: get(this.rewriters, FieldPropsEnum.default),
       form: field.state.form,
       field,
       props,
       $try,
     });
 
-    if (_.has(this.templates, FieldPropsEnum.default)) {
-      return _.get(this.templates, name)(args);
+    if (has(this.templates, FieldPropsEnum.default)) {
+      return get(this.templates, name)(args);
     }
 
-    if (_.has(this.rewriters, name)) {
+    if (has(this.rewriters, name)) {
       const $bindings = {};
 
-      _.each(_.get(this.rewriters, name), ($v, $k) =>
-        _.merge($bindings, { [$v]: $try(props[$k], field[$k]) })
+      each(get(this.rewriters, name), ($v, $k) =>
+        merge($bindings, { [$v]: $try(props[$k], field[$k]) })
       );
 
       return $bindings;
     }
 
-    return _.get(this.templates, name)(args);
+    return get(this.templates, name)(args);
   }
 }

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -10,7 +10,7 @@ import {
   autorun,
   runInAction,
 } from "mobx";
-import _ from "lodash";
+import { debounce, head, isEmpty, isBoolean, isDate, isEqual, isNil, isNull, isNumber, isPlainObject, isString, map, omit, toNumber, toString } from "lodash";
 import Base from "./Base";
 
 import { $try, hasFiles, isBool, isEvent, pathToStruct, isArrayFromStruct } from "./utils";
@@ -261,7 +261,7 @@ export default class Field extends Base implements FieldInterface {
 
     this.incremental = this.hasIncrementalKeys;
 
-    this.debouncedValidation = _.debounce(
+    this.debouncedValidation = debounce(
       this.validate,
       this.state.options.get(OptionsEnum.validationDebounceWait, this),
       this.state.options.get(OptionsEnum.validationDebounceOptions, this)
@@ -289,14 +289,14 @@ export default class Field extends Base implements FieldInterface {
   get checkValidationErrors(): boolean {
     return (
       !this.validationAsyncData.valid ||
-        !_.isEmpty(this.validationErrorStack) ||
-        _.isString(this.errorAsync) ||
-        _.isString(this.errorSync)
+        !isEmpty(this.validationErrorStack) ||
+        isString(this.errorAsync) ||
+        isString(this.errorSync)
     );
   }
 
   set value(newVal) {
-    if (_.isString(newVal) && this.state.options.get(OptionsEnum.autoTrimValue, this)) {
+    if (isString(newVal) && this.state.options.get(OptionsEnum.autoTrimValue, this)) {
       newVal = newVal.trim();
     }
     if (this.$value === newVal) return;
@@ -312,9 +312,9 @@ export default class Field extends Base implements FieldInterface {
     if (!this.state.options.get(OptionsEnum.autoParseNumbers, this))
       return false;
 
-    if (_.isNumber(this.$initial) || this.type == 'number') {
+    if (isNumber(this.$initial) || this.type == 'number') {
       if (new RegExp("^-?\\d+(,\\d+)*(\\.\\d+([eE]\\d+)?)?$", "g").exec(newVal)) {
-        this.$value = this.$converter(_.toNumber(newVal));
+        this.$value = this.$converter(toNumber(newVal));
         this.$changed ++;
         if (!this.actionRunning) {
           this.state.form.$changed ++;
@@ -440,26 +440,26 @@ export default class Field extends Base implements FieldInterface {
   }
 
   get isDefault(): boolean {
-    return !_.isNil(this.default) && _.isEqual(this.default, this.value);
+    return !isNil(this.default) && isEqual(this.default, this.value);
   }
 
   get isDirty(): boolean {
     const value = this.changed ? this.value : this.initial;
-    return !_.isEqual(this.initial, value);
+    return !isEqual(this.initial, value);
   }
 
   get isPristine(): boolean {
     const value = this.changed ? this.value : this.initial;
-    return _.isEqual(this.initial, value);
+    return isEqual(this.initial, value);
   }
 
   get isEmpty(): boolean {
     if (this.hasNestedFields) return this.check(FieldPropsEnum.isEmpty, true);
-    if (_.isBoolean(this.value)) return !!this.$value;
-    if (_.isNumber(this.value)) return false;
-    if (_.isDate(this.value)) return false;
-    if (_.isNull(this.value)) return false;
-    return _.isEmpty(this.value);
+    if (isBoolean(this.value)) return !!this.$value;
+    if (isNumber(this.value)) return false;
+    if (isDate(this.value)) return false;
+    if (isNull(this.value)) return false;
+    return isEmpty(this.value);
   }
 
   get focused(): boolean {
@@ -486,8 +486,8 @@ export default class Field extends Base implements FieldInterface {
       isBool($, this.value) ? $.target.checked : $.target.value;
 
     // assume "v" or "e" are the values
-    if (_.isNil(e) || _.isNil(e.target)) {
-      if (!_.isNil(v) && !_.isNil(v.target)) {
+    if (isNil(e) || isNil(e.target)) {
+      if (!isNil(v) && !isNil(v.target)) {
         v = $get(v); // eslint-disable-line
       }
 
@@ -495,7 +495,7 @@ export default class Field extends Base implements FieldInterface {
       return;
     }
 
-    if (!_.isNil(e.target)) {
+    if (!isNil(e.target)) {
       this.value = $get(e);
       return;
     }
@@ -551,11 +551,11 @@ export default class Field extends Base implements FieldInterface {
         let files: unknown[] | null = null;
 
         if (isEvent(e) && hasFiles(e)) {
-          files = _.map(e.target.files);
+          files = map(e.target.files);
         }
 
         this.files = [
-          ..._.map(this.files),
+          ...map(this.files),
           ...(files || args)
         ];
       })
@@ -592,10 +592,10 @@ export default class Field extends Base implements FieldInterface {
 
     const { $type, $input, $output, $converter, $converters, $computed } = $props;
 
-    if (_.isPlainObject($data)) {
+    if (isPlainObject($data)) {
       const { type, input, output, converter, converters, computed } = $data;
 
-      this.name = _.toString($data.name || $key);
+      this.name = toString($data.name || $key);
       this.$type = $type || type || "text";
       this.$converter = $try($converter, $converters, converter, converters, this.$converter);
       this.$input = $try($input, input, this.$input);
@@ -634,7 +634,7 @@ export default class Field extends Base implements FieldInterface {
     }
 
     /* The field IS the value here */
-    this.name = _.toString($key);
+    this.name = toString($key);
     this.$type = $type || "text";
     this.$converter = $try($converter, $converters, this.$converter);
     this.$input = $try($input, this.$input);
@@ -691,7 +691,7 @@ export default class Field extends Base implements FieldInterface {
   //   const { drivers } = this.state.form.validator;
   //   const form = this.state.form.name ? `${this.state.form.name}/` : "";
 
-  //   if (_.isNil(drivers.dvr) && !_.isNil(this.rules)) {
+  //   if (isNil(drivers.dvr) && !isNil(this.rules)) {
   //     throw new Error(
   //       `The DVR validation rules are defined but no DVR plugin provided. Field: "${
   //         form + this.path
@@ -699,7 +699,7 @@ export default class Field extends Base implements FieldInterface {
   //     );
   //   }
 
-  //   if (_.isNil(drivers.vjf) && !_.isNil(this.validators)) {
+  //   if (isNil(drivers.vjf) && !isNil(this.validators)) {
   //     throw new Error(
   //       `The VJF validators functions are defined but no VJF plugin provided. Field: "${
   //         form + this.path
@@ -709,16 +709,16 @@ export default class Field extends Base implements FieldInterface {
   // }
 
   initNestedFields(field: any, update: boolean): void {
-    const fields = _.isNil(field) ? null : field.fields;
+    const fields = isNil(field) ? null : field.fields;
 
-    if (Array.isArray(fields) && !_.isEmpty(fields)) {
+    if (Array.isArray(fields) && !isEmpty(fields)) {
       this.hasInitialNestedFields = true;
     }
 
     this.initFields({ fields }, update);
 
-    if (!update && Array.isArray(fields) && _.isEmpty(fields)) {
-      if (Array.isArray(this.value) && !_.isEmpty(this.value)) {
+    if (!update && Array.isArray(fields) && isEmpty(fields)) {
+      if (Array.isArray(this.value) && !isEmpty(this.value)) {
         this.hasInitialNestedFields = true;
         this.initFields({ fields, values: this.value }, update);
       }
@@ -817,13 +817,13 @@ export default class Field extends Base implements FieldInterface {
   }
 
   trim(): void {
-    if (!_.isString(this.value)) return;
+    if (!isString(this.value)) return;
     this.$value = this.value.trim();
   }
 
   showErrors(show: boolean = true, deep: boolean = true): void {
     this.showError = show;
-    this.errorSync = _.head(this.validationErrorStack) as string || null;
+    this.errorSync = head(this.validationErrorStack) as string || null;
     this.errorAsync = !this.validationAsyncData.valid ? this.validationAsyncData.message : null
     deep && this.each((field: FieldInterface) => field.showErrors(show, deep));
   }
@@ -868,7 +868,7 @@ export default class Field extends Base implements FieldInterface {
     let fn: any;
     if (type === FieldPropsEnum.observers) fn = this.observe;
     if (type === FieldPropsEnum.interceptors) fn = this.intercept;
-    this[`$${type}`].map((obj: any) => fn(_.omit(obj, FieldPropsEnum.path)));
+    this[`$${type}`].map((obj: any) => fn(omit(obj, FieldPropsEnum.path)));
   }
 
   bind(props = {}) {
@@ -879,7 +879,7 @@ export default class Field extends Base implements FieldInterface {
   }
 
   update(fields: any): void {
-    if (!_.isPlainObject(fields)) {
+    if (!isPlainObject(fields)) {
       throw new Error("The update() method accepts only plain objects.");
     }
     const fallback = this.state.options.get(OptionsEnum.fallback, this);

--- a/src/Form.ts
+++ b/src/Form.ts
@@ -6,7 +6,7 @@ import {
   autorun,
   runInAction,
 } from "mobx";
-import _ from "lodash";
+import { debounce, each, merge } from "lodash";
 
 import Base from "./Base";
 import Validator from "./Validator";
@@ -71,7 +71,7 @@ export default class Form extends Base implements FormInterface {
     runInAction(() => (this.$handlers = handlers));
 
     // load data from initializers methods
-    const initial = _.each(
+    const initial = each(
       {
         setup,
         options,
@@ -80,7 +80,7 @@ export default class Form extends Base implements FormInterface {
       },
       (val, key) =>
         typeof (this as any)[key] === "function"
-          ? _.merge(val, (this as any)[key].apply(this, [this]))
+          ? merge(val, (this as any)[key].apply(this, [this]))
           : val
     );
 
@@ -106,7 +106,7 @@ export default class Form extends Base implements FormInterface {
 
     this.initFields(initial.setup);
 
-    this.debouncedValidation = _.debounce(
+    this.debouncedValidation = debounce(
       this.validate,
       this.state.options.get(OptionsEnum.validationDebounceWait),
       this.state.options.get(OptionsEnum.validationDebounceOptions)

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -7,7 +7,7 @@ import {
   makeObservable,
 } from "mobx";
 
-import _ from "lodash";
+import { get, has } from "lodash";
 
 import { uniqueId } from "./utils";
 
@@ -74,14 +74,14 @@ export default class Options implements OptionsInterface {
 
   get(key: string, field: any = null): OptionsModel {
     // handle field option
-    if (_.has(field, "path")) {
-      if (_.has(field.$options, key)) {
+    if (has(field, "path")) {
+      if (has(field.$options, key)) {
         return field.$options[key];
       }
     }
 
     // fallback on global form options
-    if (key) return _.get(this.options, key);
+    if (key) return get(this.options, key);
     return toJS(this.options);
   }
 

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,5 +1,5 @@
 import { observe } from "mobx";
-import _ from "lodash";
+import { get, isString, pick } from "lodash";
 
 import Options from "./Options";
 import Bindings from "./Bindings";
@@ -61,7 +61,7 @@ export default class State implements StateInterface {
   }
 
   initProps(initial: any = {}) {
-    const initialProps: any = _.pick(initial, [
+    const initialProps: any = pick(initial, [
       ...props.editable,
       ...props.separated,
       ...props.validation,
@@ -121,7 +121,7 @@ export default class State implements StateInterface {
   }
 
   extra(data: any | null = null): any | null {
-    if (_.isString(data)) return _.get(this.$extra, data);
+    if (isString(data)) return get(this.$extra, data);
     if (data === null) return this.$extra;
     this.$extra = data;
     return null;

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -1,5 +1,5 @@
 import { action, observable, makeObservable } from "mobx";
-import _ from "lodash";
+import { each, isString, map } from "lodash";
 import { $try } from "./utils";
 import ValidatorInterface, {
   DriversMap,
@@ -45,7 +45,7 @@ export default class Validator implements ValidatorInterface {
   }
 
   initDrivers(): void {
-    _.map(this.plugins, (plugin: ValidationPlugin, key: string) =>
+    map(this.plugins, (plugin: ValidationPlugin, key: string) =>
         (this.drivers[key] = (plugin && plugin.class) &&
           new plugin.class({
             config: plugin.config,
@@ -67,7 +67,7 @@ export default class Validator implements ValidatorInterface {
 
     return new Promise((resolve) => {
       // validate instance (form or filed)
-      if (instance.path || _.isString(path)) {
+      if (instance.path || isString(path)) {
         this.validateField({
           field: instance,
           showErrors,
@@ -145,7 +145,7 @@ export default class Validator implements ValidatorInterface {
       : this.drivers;
 
     // validate with all enabled drivers
-    _.each(drivers, (driver: ValidationPluginInterface) => {
+    each(drivers, (driver: ValidationPluginInterface) => {
       driver && driver.validate(instance);
       if (stopOnError && instance.hasError) return;
     });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { each, endsWith, filter, get, has, isBoolean, isDate, isEmpty, isNumber, isObject, isPlainObject, isString, last, map, merge, reduceRight, replace, set, split, startsWith, transform, trimEnd, values as lodashValues, without } from "lodash";
 import { FieldPropsEnum, SeparatedPropsMode } from "./models/FieldProps";
 import {
   $try,
@@ -18,17 +18,17 @@ const defaultValue = ({
   fallbackValueOption = "",
 }: any): null | false | 0 | [] | "" => {
   if (Array.isArray(value) || isEmptyArray) return [];
-  if (nullable || _.isDate(value) || type === "date" || type === "datetime-local") return null;
-  if (_.isNumber(value) || type === "number") return 0;
-  if (_.isBoolean(value) || type === "checkbox") return false;
-  if (_.isString(value) || type === "file") return "";
+  if (nullable || isDate(value) || type === "date" || type === "datetime-local") return null;
+  if (isNumber(value) || type === "number") return 0;
+  if (isBoolean(value) || type === "checkbox") return false;
+  if (isString(value) || type === "file") return "";
   return fallbackValueOption;
 };
 
 const parsePath = (path: string): string => {
   let $path = path;
-  $path = _.replace($path, new RegExp("\\[", "g"), ".");
-  $path = _.replace($path, new RegExp("\\]", "g"), "");
+  $path = replace($path, new RegExp("\\[", "g"), ".");
+  $path = replace($path, new RegExp("\\]", "g"), "");
   return $path;
 };
 
@@ -50,7 +50,7 @@ const parseInput = (
   );
 
 const parseArrayProp = (val: any, prop: string, removeNullishValuesInArrays: boolean): any => {
-  const values = _.values(val);
+  const values = lodashValues(val);
   const isValProp: boolean = ([
     FieldPropsEnum.value,
     FieldPropsEnum.initial,
@@ -58,40 +58,40 @@ const parseArrayProp = (val: any, prop: string, removeNullishValuesInArrays: boo
   ] as string[]).includes(prop)
 
   if (removeNullishValuesInArrays && isValProp) {
-    return _.without(values, ...[null, undefined, ""]);
+    return without(values, ...[null, undefined, ""]);
   }
 
   return values;
 };
 
 const parseCheckArray = (field: any, value: any, prop: string, removeNullishValuesInArrays: boolean) => {
-  if (field.incremental && _.isObject(value) && _.isEmpty(value)) return [];
+  if (field.incremental && isObject(value) && isEmpty(value)) return [];
   return field.hasIncrementalKeys ? parseArrayProp(value, prop, removeNullishValuesInArrays) : value;
 }
 
 const parseCheckOutput = (field: any, prop: string, retrieveNullifiedEmptyStrings = false) => {
   if (prop === FieldPropsEnum.value || prop.startsWith("value.")) {
     const base = field.$output ? field.$output(field[FieldPropsEnum.value]) : field[FieldPropsEnum.value]
-    const value = prop.startsWith("value.") ? _.get(base, prop.substring(6)) : base
-    if (_.isString(value) && _.isEmpty(value) && retrieveNullifiedEmptyStrings) return null
+    const value = prop.startsWith("value.") ? get(base, prop.substring(6)) : base
+    if (isString(value) && isEmpty(value) && retrieveNullifiedEmptyStrings) return null
     return value;
   }
   return field[prop];
 }
 
 const defineFieldsFromStruct = (struct: string[], add: boolean = false) =>
-  _.reduceRight(
+  reduceRight(
     struct,
     ($, name) => {
       const obj: any = {};
-      if (_.endsWith(name, "[]")) {
+      if (endsWith(name, "[]")) {
         const val = add ? [$] : [];
-        obj[_.trimEnd(name, "[]")] = val;
+        obj[trimEnd(name, "[]")] = val;
         return obj;
       }
       // no brakets
       const prev = struct[struct.indexOf(name) - 1];
-      const stop = _.endsWith(prev, "[]") && _.last(struct) === name;
+      const stop = endsWith(prev, "[]") && last(struct) === name;
       if (!add && stop) return obj;
       obj[name] = $;
       return obj;
@@ -103,14 +103,14 @@ const handleFieldsArrayOfStrings = ($fields: any, add = false) => {
   let fields = $fields;
   // handle array with field struct (strings)
   if (isArrayOfStrings(fields)) {
-    fields = _.transform(
+    fields = transform(
       fields,
       ($obj, $) => {
-        const pathStruct = _.split($, ".");
+        const pathStruct = split($, ".");
         // as array of strings (with empty values)
         if (!pathStruct.length) return Object.assign($obj, { [$]: "" });
         // define flat or nested fields from pathStruct
-        return _.merge($obj, defineFieldsFromStruct(pathStruct, add));
+        return merge($obj, defineFieldsFromStruct(pathStruct, add));
       },
       {}
     );
@@ -122,10 +122,10 @@ const handleFieldsArrayOfObjects = ($fields: any) => {
   let fields = $fields;
   // handle array of objects (with unified props)
   if (isArrayOfObjects(fields)) {
-    fields = _.transform(
+    fields = transform(
       fields,
       ($obj, field) => {
-        if (hasUnifiedProps({ fields: { field } }) && !_.has(field, FieldPropsEnum.name)) return undefined;
+        if (hasUnifiedProps({ fields: { field } }) && !has(field, FieldPropsEnum.name)) return undefined;
         return Object.assign($obj, { [field.name]: field });
       },
       {}
@@ -135,7 +135,7 @@ const handleFieldsArrayOfObjects = ($fields: any) => {
 };
 
 const handleFieldsNested = (fields: any, strictProps: boolean = true): any =>
-  _.transform(
+  transform(
     fields,
     (obj, field, key) => {
       if (allowNested(field, strictProps)) {
@@ -172,8 +172,8 @@ TO:
 
 */
 const mapNestedValuesToUnifiedValues = (data: object): any =>
-  _.isPlainObject(data)
-    ? _.map(data, (value, name) => ({ value, name }))
+  isPlainObject(data)
+    ? map(data, (value, name) => ({ value, name }))
     : undefined;
 
 /* reduceValuesToUnifiedFields
@@ -206,7 +206,7 @@ TO:
 
 */
 const reduceValuesToUnifiedFields = (values: object): object =>
-  _.transform(
+  transform(
     values,
     (obj, value, key) =>
       Object.assign(obj, {
@@ -226,16 +226,16 @@ const handleFieldsPropsFallback = (
   initial: any,
   fallback: any
 ) => {
-  if (!_.has(initial, SeparatedPropsMode.values)) return fields;
+  if (!has(initial, SeparatedPropsMode.values)) return fields;
   // if the 'values' object is passed in constructor
   // then update the fields definitions
   let { values } = initial;
   if (hasUnifiedProps({ fields: initial.fields })) {
     values = reduceValuesToUnifiedFields(values);
   }
-  return _.merge(
+  return merge(
     fields,
-    _.transform(
+    transform(
       values,
       (result: any, v, k) => {
         if (Array.isArray(fields[k])) result[k] = v;
@@ -248,10 +248,10 @@ const handleFieldsPropsFallback = (
 
 const mergeSchemaDefaults = (fields: any, validator: any) => {
   if (validator) {
-    const schema = _.get(validator.plugins, "svk.config.schema");
-    if (_.isEmpty(fields) && schema && !!schema.properties) {
-      _.each(schema.properties, (prop, key) => {
-        _.set(fields, key, {
+    const schema = get(validator.plugins, "svk.config.schema");
+    if (isEmpty(fields) && schema && !!schema.properties) {
+      each(schema.properties, (prop, key) => {
+        set(fields, key, {
           value: prop.default,
           label: prop.title,
         });
@@ -266,7 +266,7 @@ const prepareFieldsData = (
   strictProps: boolean = true,
   fallback: boolean = true,
 ) => {
-  let fields = _.merge(
+  let fields = merge(
     handleFieldsArrayOfStrings(initial.fields, false),
     handleFieldsArrayOfStrings(initial.struct, false)
   );
@@ -285,12 +285,12 @@ const pathToFieldsTree = (
   add: boolean = false
 ) => {
   const structPath = pathToStruct(path);
-  const structArray = _.filter(struct, (item) =>
-    _.startsWith(item, structPath)
+  const structArray = filter(struct, (item) =>
+    startsWith(item, structPath)
   );
   const $tree = handleFieldsArrayOfStrings(structArray, add);
-  const $struct = _.replace(structPath, new RegExp("\\[]", "g"), `[${n}]`);
-  const fields = handleFieldsNested(_.get($tree, $struct));
+  const $struct = replace(structPath, new RegExp("\\[]", "g"), `[${n}]`);
+  const fields = handleFieldsNested(get($tree, $struct));
 
   // fix issues #614 & #615
   struct.length && struct

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { ary, endsWith, every, has, intersection, isBoolean, isDate, isEmpty, isInteger, isNil, isObject, isPlainObject, isString, isUndefined, keys, map, max, partial, replace, some, toNumber, trim, union, uniqueId as _uniqueId, values } from "lodash";
 import { ObservableMap, values as mobxValues, keys as mobxKeys } from "mobx";
 import { FieldInterface } from "./models/FieldInterface";
 import { AllowedFieldPropsTypes, FieldPropsEnum, FieldPropsOccurrence } from "./models/FieldProps";
@@ -24,8 +24,8 @@ const checkObserve = (collection: object[]) => (change: any) =>
 const checkPropOccurrence = ({ type, data }: any): boolean => {
   let $check: any;
   switch (type) {
-    case FieldPropsOccurrence.some: $check = ($data: object) => _.some($data, Boolean); break;
-    case FieldPropsOccurrence.every: $check = ($data: object) => _.every($data, Boolean); break;
+    case FieldPropsOccurrence.some: $check = ($data: object) => some($data, Boolean); break;
+    case FieldPropsOccurrence.every: $check = ($data: object) => every($data, Boolean); break;
     default: throw new Error('Occurrence not found for specified prop');
   }
   return $check(data);
@@ -69,7 +69,7 @@ const hasProps = ($type: string, $data: any): boolean => {
       $props = null;
   }
 
-  return _.intersection($data, $props).length > 0;
+  return intersection($data, $props).length > 0;
 };
 
 /**
@@ -85,16 +85,16 @@ const allowedProps = (type: string, data: string[]): void => {
   Throw Error if undefined Fields
 */
 const throwError = (path: string, fields: any, msg: null | string = null): void => {
-  if (!_.isNil(fields)) return;
-  const $msg = _.isNil(msg) ? "The selected field is not defined" : msg;
+  if (!isNil(fields)) return;
+  const $msg = isNil(msg) ? "The selected field is not defined" : msg;
   throw new Error(`${$msg} (${path})`);
 };
 
 const pathToStruct = (path: string): string => {
   let struct;
-  struct = _.replace(path, new RegExp("[.]\\d+($|.)", "g"), "[].");
-  struct = _.replace(struct, "..", ".");
-  struct = _.trim(struct, ".");
+  struct = replace(path, new RegExp("[.]\\d+($|.)", "g"), "[].");
+  struct = replace(struct, "..", ".");
+  struct = trim(struct, ".");
   return struct;
 };
 
@@ -102,24 +102,24 @@ const isArrayFromStruct = (struct: string[], structPath: string): boolean => {
   if (isArrayOfStrings(struct)) return !!struct
     .filter((s) => s.startsWith(structPath))
     .find((s) => s.substring(structPath.length) === "[]")
-    || _.endsWith(struct?.find((e) => e === structPath), '[]');
+    || endsWith(struct?.find((e) => e === structPath), '[]');
   else return false;
 };
 
 const hasSome = (obj: any, keys: any): boolean =>
-  _.some(keys, _.partial(_.has, obj));
+  some(keys, partial(has, obj));
 
 const isEmptyArray = (field: any): boolean =>
-  _.isEmpty(field) && Array.isArray(field);
+  isEmpty(field) && Array.isArray(field);
 
 const isArrayOfStrings = (struct: any): boolean =>
-  Array.isArray(struct) && _.every(struct, _.isString);
+  Array.isArray(struct) && every(struct, isString);
 
 const isArrayOfObjects = (fields: any): boolean =>
-  Array.isArray(fields) && _.every(fields, _.isPlainObject);
+  Array.isArray(fields) && every(fields, isPlainObject);
 
 const getKeys = (fields: any) =>
-  _.union(..._.map(_.values(fields), (values) => _.keys(values)));
+  union(...map(values(fields), (values) => keys(values)));
 
 const hasUnifiedProps = ({ fields }: any) =>
   !isArrayOfStrings({ fields }) && hasProps(AllowedFieldPropsTypes.editable, getKeys(fields));
@@ -128,10 +128,10 @@ const hasSeparatedProps = (initial: any): boolean =>
   hasSome(initial, props.separated) || hasSome(initial, props.validation);
 
 const allowNested = (field: any, strictProps: boolean): boolean =>
-  _.isObject(field) &&
-  !_.isDate(field) &&
-  !_.has(field, FieldPropsEnum.fields) &&
-  !_.has(field, FieldPropsEnum.class) &&
+  isObject(field) &&
+  !isDate(field) &&
+  !has(field, FieldPropsEnum.fields) &&
+  !has(field, FieldPropsEnum.class) &&
     (!hasSome(field, [
       ...props.editable,
       ...props.handlers,
@@ -140,29 +140,29 @@ const allowNested = (field: any, strictProps: boolean): boolean =>
     ]) || strictProps);
 
 const parseIntKeys = (fields: any) =>
-  _.map(getObservableMapKeys(fields), _.ary(_.toNumber, 1));
+  map(getObservableMapKeys(fields), ary(toNumber, 1));
 
 const hasIntKeys = (fields: any): boolean =>
-  _.every(parseIntKeys(fields), _.isInteger);
+  every(parseIntKeys(fields), isInteger);
 
 const maxKey = (fields: any): number => {
-  const max = _.max(parseIntKeys(fields));
-  return _.isUndefined(max) ? 0 : max + 1;
+  const maxVal = max(parseIntKeys(fields));
+  return isUndefined(maxVal) ? 0 : maxVal + 1;
 };
 
 const uniqueId = (field: any): string =>
-  _.uniqueId([_.replace(field.path, new RegExp("\\.", "g"), "-"), "--"].join(""));
+  _uniqueId([replace(field.path, new RegExp("\\.", "g"), "-"), "--"].join(""));
 
 const isEvent = (obj: any): boolean => {
-  if (_.isNil(obj) || typeof Event === "undefined") return false;
-  return obj instanceof Event || !_.isNil(obj.target);
+  if (isNil(obj) || typeof Event === "undefined") return false;
+  return obj instanceof Event || !isNil(obj.target);
 };
 
 const hasFiles = ($: any): boolean =>
   $.target.files && $.target.files.length !== 0;
 
 const isBool = ($: any, val: any): boolean =>
-  _.isBoolean(val) && _.isBoolean($.target.checked);
+  isBoolean(val) && isBoolean($.target.checked);
 
 const $try = (...args: any[]) => {
   for (const val of args) {

--- a/src/validators/DVR.ts
+++ b/src/validators/DVR.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { filter, forIn, head, isEmpty, isString, split } from "lodash";
 import FieldInterface from "../models/FieldInterface";
 import FormInterface from "../models/FormInterface";
 import StateInterface from "../models/StateInterface";
@@ -48,12 +48,12 @@ export class DVR<TValidator = any>
 
   makeLabels(validation: any, field: FieldInterface) {
     const labels = { [field.path]: field.label };
-    _.forIn(validation.rules[field.path], (rule) => {
+    forIn(validation.rules[field.path], (rule) => {
       if (
         typeof rule.value === "string" &&
         rule.name.match(/^(required_|same|different)/)
       ) {
-        _.forIn(rule.value.split(","), (p, i: any) => {
+        forIn(rule.value.split(","), (p, i: any) => {
           if (!rule.name.match(/^required_(if|unless)/) || i % 2 === 0) {
             const f = this.state.form.$(p);
             if (f && f.path && f.label) {
@@ -76,17 +76,17 @@ export class DVR<TValidator = any>
 
   validateFieldSync(field: FieldInterface, data: any) {
     const $rules = this.rules(field.rules, "sync");
-    if (_.isEmpty($rules[0])) return;
+    if (isEmpty($rules[0])) return;
     const rules = { [field.path]: $rules };
     const validation = new (this.validator as any)(data, rules);
     this.makeLabels(validation, field);
     if (validation.passes()) return;
-    field.invalidate(_.head(validation.errors.get(field.path)), false);
+    field.invalidate(head(validation.errors.get(field.path)), false);
   }
 
   validateFieldAsync(field: FieldInterface, data: any) {
     const $rules = this.rules(field.rules, "async");
-    if (_.isEmpty($rules[0])) return;
+    if (isEmpty($rules[0])) return;
     const rules = { [field.path]: $rules };
     const validation = new (this.validator as any)(data, rules);
     this.makeLabels(validation, field);
@@ -113,7 +113,7 @@ export class DVR<TValidator = any>
   ) {
     field.setValidationAsyncData(
       false,
-      _.head(validation.errors.get(field.path))
+      head(validation.errors.get(field.path))
     );
     this.executeAsyncValidation(field);
     resolve();
@@ -126,12 +126,12 @@ export class DVR<TValidator = any>
   }
 
   rules(rules: any, type: "sync" | "async") {
-    const $rules = _.isString(rules) ? _.split(rules, "|") : rules;
+    const $rules = isString(rules) ? split(rules, "|") : rules;
     const v = new (this.validator as any)();
-    return _.filter($rules, ($rule) =>
+    return filter($rules, ($rule) =>
       type === "async"
-        ? v.getRule(_.split($rule, ":")[0])?.async
-        : !v.getRule(_.split($rule, ":")[0])?.async
+        ? v.getRule(split($rule, ":")[0])?.async
+        : !v.getRule(split($rule, ":")[0])?.async
     );
   }
 }

--- a/src/validators/JOI.ts
+++ b/src/validators/JOI.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import FieldInterface from "../models/FieldInterface";
 import FormInterface from "../models/FormInterface";
 import StateInterface from "../models/StateInterface";

--- a/src/validators/SVK.ts
+++ b/src/validators/SVK.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { find, includes, replace, trimStart } from "lodash";
 import FieldInterface from "../models/FieldInterface";
 import FormInterface from "../models/FormInterface";
 import StateInterface from "../models/StateInterface";
@@ -95,12 +95,12 @@ class SVK<TValidator = any> implements ValidationPluginInterface<TValidator> {
   }
 
   findError(path: string, errors: any[]): any {
-    return _.find(errors, ({ dataPath }) => {
+    return find(errors, ({ dataPath }) => {
       let $dataPath;
-      $dataPath = _.trimStart(dataPath, ".");
-      $dataPath = _.replace($dataPath, "]", "");
-      $dataPath = _.replace($dataPath, "[", ".");
-      return _.includes($dataPath, path);
+      $dataPath = trimStart(dataPath, ".");
+      $dataPath = replace($dataPath, "]", "");
+      $dataPath = replace($dataPath, "[", ".");
+      return includes($dataPath, path);
     });
   }
 

--- a/src/validators/VJF.ts
+++ b/src/validators/VJF.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { isBoolean, isString } from "lodash";
 import FieldInterface from "../models/FieldInterface";
 import FormInterface from "../models/FormInterface";
 import StateInterface from "../models/StateInterface";
@@ -99,11 +99,11 @@ export class VJF<TValidator = any> implements ValidationPluginInterface<TValidat
       return [result[0] || false, result[1] || "Error"];
     }
 
-    if (_.isBoolean(result)) {
+    if (isBoolean(result)) {
       return [result, "Error"];
     }
 
-    if (_.isString(result)) {
+    if (isString(result)) {
       return [false, result];
     }
 

--- a/src/validators/ZOD.ts
+++ b/src/validators/ZOD.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { get } from "lodash";
 import FieldInterface from "../models/FieldInterface";
 import FormInterface from "../models/FormInterface";
 import StateInterface from "../models/StateInterface";
@@ -47,7 +47,7 @@ export class ZOD<TValidator = any> implements ValidationPluginInterface {
 
     if (result.success) return;
 
-    const fieldErrors = _.get(
+    const fieldErrors = get(
       (result as any).error.format(),
       field.path
     )?._errors;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -67,7 +67,7 @@
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */


### PR DESCRIPTION
**Toolchain simplification**
Removes `@babel/core`, `@rollup/plugin-babel`, and `babel-plugin-lodash` entirely (one less transpilation layer).

**ESM build gets real tree-shaking**
The old ESM build used `babel-plugin-lodash` to cherry-pick `lodash` methods at build time — but the output still referenced CJS `lodash` paths, so downstream bundlers couldn't tree-shake further. The new ESM build externalizes `lodash-es`, so consumers' bundlers (Vite, webpack, Rollup) can eliminate any lodash functions they don't transitively use.

**Smaller, more modern output (ES2022 target)**
Native async/await, optional chaining, class fields, etc. — no downcompilation. Downstream consumers can target whatever they need; the library shouldn't be doing it for them.

<img width="959" height="210" alt="-11 9 kB(-9" src="https://github.com/user-attachments/assets/dc16de57-2fbb-4d85-85ce-b2ec09b68604" />

⬆️ The UMD bundle size reduction (-17% dev, -19% min) is a regression fix from the Rollup migration — `babel-plugin-lodash` was transforming `lodash` imports to per-method paths (e.g. `lodash/merge`), which bypassed the external: `['lodash']` rule and caused cherry-picked `lodash` methods to be bundled unintentionally. This PR restores correct `lodash` externalization in the UMD build, consistent with the original Webpack behavior.

---

**⚠️ Caveat/for your consideration:** Both `lodash` and `lodash-es` are listed as dependencies so consumers don't need to install either manually (`lodash` for CJS/UMD, `lodash-es` for ESM). The alternative would be declaring them as peer dependencies, requiring consumers to explicitly install whichever variant matches their module format. That change would be easy to do. It's just a DX decision.